### PR TITLE
Update project GAV to `org.apache.directory.scim:*:2.23-SNAPSHOT`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,18 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 FROM jboss/wildfly
 
 RUN /opt/jboss/wildfly/bin/add-user.sh vadmin vpassword --silent

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.apache.directory.scim</groupId>
   <artifactId>scim-parent</artifactId>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.23-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SCIM - Parent</name>
   <description>Apache Directory SCIMple - JavaEE implementation of the SCIM version 2.0 specification (RFC7642, RFC7643 and RFC7644)</description>
@@ -109,27 +109,27 @@
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-protocol</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.23-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-schema</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.23-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-common</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.23-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-tools-common</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.23-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-server-common</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.23-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,19 +18,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>edu.psu.swe.scim</groupId>
+  <parent>
+    <groupId>org.apache.directory.project</groupId>
+    <artifactId>project</artifactId>
+    <version>42</version>
+  </parent>
+
+  <groupId>org.apache.directory.scim</groupId>
   <artifactId>scim-parent</artifactId>
-  <version>2.23-SNAPSHOT</version>
+  <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SCIM - Parent</name>
-  <description>Penn State's Open Source JavaEE implmentation of the SCIM version 2.0 specification (RFC7642, RFC7643 and RFC7644)</description>
-  <url>https://github.com/PennState/scim</url>
+  <description>Apache Directory SCIMple - JavaEE implementation of the SCIM version 2.0 specification (RFC7642, RFC7643 and RFC7644)</description>
+  <url>https://github.com/apache/directory-scimple</url>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
 
+    <!-- TODO: is this needed? -->
     <version.gwt>2.8.0</version.gwt>
     <version.jackson>2.8.8</version.jackson>
     <version.lombok>1.16.14</version.lombok>
@@ -99,26 +105,33 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Project Modules -->
       <dependency>
-        <groupId>edu.psu.swe.scim</groupId>
+        <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-protocol</artifactId>
-        <version>${project.version}</version>
+        <version>1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>edu.psu.swe.scim</groupId>
+        <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-schema</artifactId>
-        <version>${project.version}</version>
+        <version>1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>edu.psu.swe.scim</groupId>
+        <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-common</artifactId>
-        <version>${project.version}</version>
+        <version>1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>edu.psu.swe.scim</groupId>
+        <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-tools-common</artifactId>
-        <version>${project.version}</version>
+        <version>1.0-SNAPSHOT</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-server-common</artifactId>
+        <version>1.0-SNAPSHOT</version>
+      </dependency>
+
       <dependency>
         <groupId>edu.psu.swe.commons</groupId>
         <artifactId>commons-jaxrs</artifactId>
@@ -263,48 +276,37 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-        <version>1.4.5</version>
-        <!-- <configuration> -->
-        <!-- <failBuildOnCVSS>10</failBuildOnCVSS> -->
-        <!-- </configuration> -->
-        <executions>
-          <execution>
-            <goals>
-              <goal>aggregate</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <serverId>rao</serverId>
+          <nexusUrl>https://repository.apache.org/</nexusUrl>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>
+
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <configuration>
+            <!-- parent pom currently defines v1.7 -->
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.1.1</version>
           <configuration>
             <archive>
               <manifest>
@@ -323,7 +325,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.2</version>
           <configuration>
             <archive>
               <manifest>
@@ -357,23 +358,22 @@
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <flowInitContext>
-              <versionTagPrefix>SCIM-</versionTagPrefix>
+              <versionTagPrefix>SCIMple-</versionTagPrefix>
             </flowInitContext>
           </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+                <goal>test-jar</goal>
+              </goals>
+            </execution>
+          </executions>
           <configuration>
             <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
@@ -391,11 +391,42 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <version>0.12</version>
+          <configuration>
+            <excludes>
+              <exclude>**/README.md</exclude>
+              <exclude>**/*.json</exclude>
+              <exclude>**/*.iml</exclude>
+            </excludes>
+          </configuration>
+          </plugin>
       </plugins>
     </pluginManagement>
   </build>
 
   <profiles>
+    <profile>
+      <id>ci</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>acceptance-tests</id>
       <build>
@@ -457,7 +488,7 @@
         </plugins>
       </build>
     </profile>
-    
+
     <profile>
       <id>sign-artifacts</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.apache.directory.scim</groupId>
   <artifactId>scim-parent</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SCIM - Parent</name>
   <description>Apache Directory SCIMple - JavaEE implementation of the SCIM version 2.0 specification (RFC7642, RFC7643 and RFC7644)</description>
@@ -109,27 +109,27 @@
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-protocol</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-schema</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-common</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-tools-common</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-server-common</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim-client</artifactId>
   <name>SCIM - Client</name>

--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -18,23 +18,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim-client</artifactId>
   <name>SCIM - Client</name>
   
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-schema</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-protocol</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
         <groupId>junit</groupId>
@@ -50,7 +48,7 @@
         <artifactId>JUnitParams</artifactId>
     </dependency>
     <dependency>
-        <groupId>edu.psu.swe.scim</groupId>
+        <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-common</artifactId>
     </dependency>
     <dependency>

--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
   <artifactId>scim-client</artifactId>
   <name>SCIM - Client</name>

--- a/scim-common/pom.xml
+++ b/scim-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-common</artifactId>

--- a/scim-common/pom.xml
+++ b/scim-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-common</artifactId>

--- a/scim-common/pom.xml
+++ b/scim-common/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-common</artifactId>
@@ -29,14 +29,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>edu.psu.swe.scim</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-protocol</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>edu.psu.swe.scim</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-schema</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/scim-compliance/pom.xml
+++ b/scim-compliance/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance</artifactId>

--- a/scim-compliance/pom.xml
+++ b/scim-compliance/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance</artifactId>

--- a/scim-compliance/pom.xml
+++ b/scim-compliance/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance</artifactId>

--- a/scim-compliance/scim-compliance-client/pom.xml
+++ b/scim-compliance/scim-compliance-client/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-compliance</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-client</artifactId>

--- a/scim-compliance/scim-compliance-client/pom.xml
+++ b/scim-compliance/scim-compliance-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-compliance</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-client</artifactId>

--- a/scim-compliance/scim-compliance-client/pom.xml
+++ b/scim-compliance/scim-compliance-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-compliance</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-client</artifactId>

--- a/scim-compliance/scim-compliance-server/pom.xml
+++ b/scim-compliance/scim-compliance-server/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-compliance</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-server</artifactId>
@@ -33,11 +33,11 @@
       <artifactId>com.eclipsesource.restfuse</artifactId>
     </dependency>
     <dependency>
-      <groupId>edu.psu.swe.scim</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>
-      <groupId>edu.psu.swe.scim</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-protocol</artifactId>
     </dependency>
     <dependency>

--- a/scim-compliance/scim-compliance-server/pom.xml
+++ b/scim-compliance/scim-compliance-server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-compliance</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-server</artifactId>

--- a/scim-compliance/scim-compliance-server/pom.xml
+++ b/scim-compliance/scim-compliance-server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-compliance</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-server</artifactId>

--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server</artifactId>

--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server</artifactId>

--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server</artifactId>

--- a/scim-server/scim-server-common/pom.xml
+++ b/scim-server/scim-server-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-server</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server-common</artifactId>

--- a/scim-server/scim-server-common/pom.xml
+++ b/scim-server/scim-server-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-server</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server-common</artifactId>

--- a/scim-server/scim-server-common/pom.xml
+++ b/scim-server/scim-server-common/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-server</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server-common</artifactId>
@@ -34,14 +34,12 @@
       <artifactId>javaee-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-schema</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-protocol</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>edu.psu.swe.commons</groupId>
@@ -123,7 +121,7 @@
 			</exclusions>
     </dependency>
     <dependency>
-      <groupId>edu.psu.swe.scim</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-common</artifactId>
     </dependency>
     <dependency>

--- a/scim-server/scim-server-common/src/main/resources/META-INF/beans.xml
+++ b/scim-server/scim-server-common/src/main/resources/META-INF/beans.xml
@@ -1,3 +1,19 @@
+<?xml version="1.0"?>
+
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"

--- a/scim-spec/pom.xml
+++ b/scim-spec/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-spec</artifactId>

--- a/scim-spec/pom.xml
+++ b/scim-spec/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-spec</artifactId>

--- a/scim-spec/pom.xml
+++ b/scim-spec/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-spec</artifactId>

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -21,10 +21,10 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>edu.psu.swe.scim</groupId>
-		<artifactId>scim-spec</artifactId>
-		<version>2.23-SNAPSHOT</version>
-	</parent>
+    <groupId>org.apache.directory.scim</groupId>
+    <artifactId>scim-spec</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
 
 	<artifactId>scim-spec-protocol</artifactId>
 	<name>SCIM - Specification - Protocol</name>
@@ -66,9 +66,8 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>${project.groupId}</groupId>
+			<groupId>org.apache.directory.scim</groupId>
 			<artifactId>scim-spec-schema</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-spec</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
 	<artifactId>scim-spec-protocol</artifactId>

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-spec</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
 	<artifactId>scim-spec-protocol</artifactId>

--- a/scim-spec/scim-spec-schema/pom.xml
+++ b/scim-spec/scim-spec-schema/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-spec</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
 	<artifactId>scim-spec-schema</artifactId>

--- a/scim-spec/scim-spec-schema/pom.xml
+++ b/scim-spec/scim-spec-schema/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-spec</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
 	<artifactId>scim-spec-schema</artifactId>

--- a/scim-spec/scim-spec-schema/pom.xml
+++ b/scim-spec/scim-spec-schema/pom.xml
@@ -19,10 +19,10 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>edu.psu.swe.scim</groupId>
-		<artifactId>scim-spec</artifactId>
-		<version>2.23-SNAPSHOT</version>
-	</parent>
+    <groupId>org.apache.directory.scim</groupId>
+    <artifactId>scim-spec</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
 
 	<artifactId>scim-spec-schema</artifactId>
 	<name>SCIM - Specification - Schema</name>

--- a/scim-tools/pom.xml
+++ b/scim-tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools</artifactId>

--- a/scim-tools/pom.xml
+++ b/scim-tools/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools</artifactId>

--- a/scim-tools/pom.xml
+++ b/scim-tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools</artifactId>

--- a/scim-tools/scim-tools-common/pom.xml
+++ b/scim-tools/scim-tools-common/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>edu.psu.swe.scim</groupId>
+    <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-tools</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools-common</artifactId>
@@ -41,7 +41,7 @@
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
     <dependency>
-      <groupId>edu.psu.swe.scim</groupId>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>

--- a/scim-tools/scim-tools-common/pom.xml
+++ b/scim-tools/scim-tools-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-tools</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools-common</artifactId>

--- a/scim-tools/scim-tools-common/pom.xml
+++ b/scim-tools/scim-tools-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-tools</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools-common</artifactId>


### PR DESCRIPTION
Set parent to `org.apache.directory.project:project` (which extends from the apache root pom)

`mvn apache-rat:check` will also pass now

Remove references to ${project.groupId} and ${project.version} when defining dependencies to project downstream consumers (note: using the release plugin or `mvn versions:set` will correctly update these versions automatically)

**NOTE:** this conflicts with #2, but I'll update #2 if/when this goes in