### PR TITLE
Add Jacoco Maven plugin to record test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <module>scim-tools</module>
     <module>scim-compliance</module>
     <module>scim-common</module>
+    <module>scim-coverage</module>
   </modules>
 
   <scm>
@@ -122,6 +123,21 @@
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-server-common</artifactId>
+        <version>2.23-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-client</artifactId>
+        <version>2.23-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-compliance-client</artifactId>
+        <version>2.23-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-compliance-server</artifactId>
         <version>2.23-SNAPSHOT</version>
       </dependency>
 
@@ -291,6 +307,21 @@
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <propertyName>jacoco.argline</propertyName>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -410,6 +441,19 @@
               <exclude>**/*.iml</exclude>
             </excludes>
           </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <!-- parent pom overrides the default, so we MUST set the jacoco argline directly -->
+              <argLine>@{jacoco.argline}</argLine>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.1</version>
           </plugin>
       </plugins>
     </pluginManagement>

--- a/scim-coverage/pom.xml
+++ b/scim-coverage/pom.xml
@@ -1,0 +1,83 @@
+<!--  Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.directory.scim</groupId>
+    <artifactId>scim-parent</artifactId>
+    <version>2.23-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>scim-test-coverage</artifactId>
+  <name>SCIM - Total Test Coverage</name>
+
+  <dependencies>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-spec-protocol</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-spec-schema</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-common</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-tools-common</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-server-common</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-client</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-compliance-client</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.directory.scim</groupId>
+        <artifactId>scim-compliance-server</artifactId>
+      </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>jacoco-report</id>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Each module will output a coverage file, but only a total project report is generated
at {root}/scim-coverage/target/site/jacoco-aggregate/index.html

NOTE: this is layered on PR #3, diff to review: a48f7db