### PR TITLE
Update OWASP dep scan configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <!-- TODO: is this needed? -->
     <version.gwt>2.8.0</version.gwt>
-    <version.jackson>2.8.8</version.jackson>
+    <version.jackson>2.9.5</version.jackson>
     <version.lombok>1.16.14</version.lombok>
     <version.lombok.plugin>${version.lombok}.0</version.lombok.plugin>
     <version.restfuse>1.2.0</version.restfuse>
@@ -294,6 +294,9 @@
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
           <version>3.1.1</version>
+          <configuration>
+            <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -418,7 +421,7 @@
             <executions>
               <execution>
                 <goals>
-                  <goal>aggregate</goal>
+                  <goal>check</goal>
                 </goals>
               </execution>
             </executions>

--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -54,7 +54,11 @@
     <dependency>
       <groupId>edu.psu.swe.commons</groupId>
       <artifactId>commons-jaxrs</artifactId>
-      <version>1.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   

--- a/scim-compliance/scim-compliance-server/pom.xml
+++ b/scim-compliance/scim-compliance-server/pom.xml
@@ -27,6 +27,19 @@
   <artifactId>scim-compliance-server</artifactId>
   <name>SCIM - Compliance - Server</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- update the version of jetty that restfuse uses, fixes CVE-2017-9735-->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>9.4.8.v20180619</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.restfuse</groupId>

--- a/scim-server/scim-server-common/pom.xml
+++ b/scim-server/scim-server-common/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>com.flipkart.zjsonpatch</groupId>
       <artifactId>zjsonpatch</artifactId>
-      <version>0.2.4</version>
+      <version>0.4.4</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Use the `check` goal instead of `aggregate` which can only be run post build (or as part of a site/report build)

Updated dependencies with scan:
* commons-jaxrs - correct version already in dep management
* restfuse - uses an out of date version of jetty
* zjsonpatch - previous version used an old version of commons-collections4