### PR TITLE
Allow Provider implementations to handle JAX-RS exceptions by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,18 @@
         <version>${version.restfuse}</version>
       </dependency>
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>java-hamcrest</artifactId>
+        <version>2.0.0.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>eu.codearte.catch-exception</groupId>
+        <artifactId>catch-exception</artifactId>
+        <version>1.4.6</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt</artifactId>
         <version>${version.gwt}</version>

--- a/scim-server/scim-server-common/pom.xml
+++ b/scim-server/scim-server-common/pom.xml
@@ -90,6 +90,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>eu.codearte.catch-exception</groupId>
+      <artifactId>catch-exception</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
       <version>1.5.0</version>

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/provider/Provider.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/provider/Provider.java
@@ -21,6 +21,7 @@ package org.apache.directory.scim.server.provider;
 
 import java.util.List;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -135,6 +136,10 @@ public interface Provider<T extends ScimResource> {
    * @return
    */
   default Response handleException(Throwable unhandled) {
+    // Allow for ErrorMessageViolationExceptionMapper to handle JAX-RS exceptions by default
+    if (unhandled instanceof WebApplicationException) {
+      throw (WebApplicationException) unhandled;
+    }
     return BaseResourceTypeResourceImpl.createGenericExceptionResponse(unhandled, Status.INTERNAL_SERVER_ERROR);
   }
 }

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -708,7 +708,7 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
       myStatus = Status.INTERNAL_SERVER_ERROR;
     }
 
-    ErrorResponse er = new ErrorResponse(myStatus, e1.getMessage());
+    ErrorResponse er = new ErrorResponse(myStatus, e1 != null ? e1.getMessage() : "Unknown Server Error");
     return er.toResponse();
   }
 

--- a/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/provider/ProviderTest.java
+++ b/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/provider/ProviderTest.java
@@ -1,0 +1,82 @@
+package org.apache.directory.scim.server.provider;
+
+import org.apache.directory.scim.spec.protocol.data.ErrorResponse;
+import org.apache.directory.scim.spec.protocol.filter.FilterResponse;
+import org.apache.directory.scim.spec.protocol.search.Filter;
+import org.apache.directory.scim.spec.protocol.search.PageRequest;
+import org.apache.directory.scim.spec.protocol.search.SortRequest;
+import org.apache.directory.scim.spec.resources.ScimExtension;
+import org.apache.directory.scim.spec.resources.ScimResource;
+import org.junit.Test;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class ProviderTest {
+
+  @Test
+  public void handleException_jaxrsExceptionTest() {
+
+    Exception e = new WebApplicationException();
+    catchException(new ProviderAdapter()).handleException(e);
+    assertThat(caughtException(), sameInstance(e));
+  }
+
+  @Test
+  public void handleException_runtimeExceptionTest() {
+
+    Exception e = new RuntimeException("fake test exception");
+    Response response = new ProviderAdapter().handleException(e);
+    assertThat(response.getStatus(), is(500));
+    assertThat(((ErrorResponse)response.getEntity()).getDetail(), is("fake test exception"));
+  }
+
+  @Test
+  public void handleException_nullExceptionTest() {
+
+    Response response = new ProviderAdapter().handleException(null);
+    assertThat(response.getStatus(), is(500));
+    assertThat(((ErrorResponse)response.getEntity()).getDetail(), is("Unknown Server Error"));
+  }
+
+  private class ProviderAdapter implements Provider {
+
+    @Override
+    public ScimResource create(ScimResource resource) {
+      return null;
+    }
+
+    @Override
+    public ScimResource update(UpdateRequest updateRequest) {
+      return null;
+    }
+
+    @Override
+    public ScimResource get(String id) {
+      return null;
+    }
+
+    @Override
+    public FilterResponse find(Filter filter, PageRequest pageRequest, SortRequest sortRequest) {
+      return null;
+    }
+
+    @Override
+    public void delete(String id) {
+
+    }
+
+    @Override
+    public List<Class<? extends ScimExtension>> getExtensionList() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
WebApplicationException will be handled automatically by ErrorMessageViolationExceptionMapper by default