### PR TITLE
Add OWASP suppression to ignore false positives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,14 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!-- update the version of jetty that restfuse uses, fixes CVE-2017-9735-->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>9.4.8.v20180619</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>pl.pragmatists</groupId>
         <artifactId>JUnitParams</artifactId>
@@ -332,6 +340,7 @@
           <version>3.1.1</version>
           <configuration>
             <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+            <suppressionFile>${session.executionRootDirectory}/src/owasp/suppression.xml</suppressionFile>
           </configuration>
         </plugin>
         <plugin>

--- a/scim-compliance/scim-compliance-server/pom.xml
+++ b/scim-compliance/scim-compliance-server/pom.xml
@@ -27,19 +27,6 @@
   <artifactId>scim-compliance-server</artifactId>
   <name>SCIM - Compliance - Server</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- update the version of jetty that restfuse uses, fixes CVE-2017-9735-->
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-bom</artifactId>
-        <version>9.4.8.v20180619</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>com.restfuse</groupId>

--- a/src/owasp/suppression.xml
+++ b/src/owasp/suppression.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License. -->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+
+  <!-- Wrong GAV detection -->
+  <suppress>
+   <notes><![CDATA[file name: scim-server-common-*.jar]]></notes>
+   <gav regex="true">^org\.apache\.directory\.scim:.*$</gav>
+   <cpe>cpe:/a:apache:apache_http_server</cpe>
+  </suppress>
+  <suppress>
+   <notes><![CDATA[file name: scim-server-common-*.jar]]></notes>
+   <gav regex="true">^org\.apache\.directory\.scim:.*$</gav>
+   <cpe>cpe:/a:apache:http_server</cpe>
+  </suppress>
+
+</suppressions>


### PR DESCRIPTION
Also moved the jetty-bom import to root pom, as scim-coverage wasn't getting the updated versions