### PR TITLE
HOLD:  Makes Jackson/JAXB configuration more portable between containers

### DIFF
--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/DeserializerConfigurer.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/DeserializerConfigurer.java
@@ -1,0 +1,45 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ 
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.server.rest;
+
+import javax.inject.Inject;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
+import org.apache.directory.scim.server.schema.Registry;
+import org.apache.directory.scim.spec.resources.ScimResource;
+
+/**
+ * Adds a {@link ScimResourceDeserializer} to an @{link ObjectMapper}.
+ */
+@Provider
+public class DeserializerConfigurer {
+
+  @Inject
+  public DeserializerConfigurer(Registry registry, ObjectMapper objectMapper) {
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(ScimResource.class, new ScimResourceDeserializer(registry, objectMapper));
+    objectMapper.registerModule(module);
+    objectMapper.registerModule(new JaxbAnnotationModule());
+  }
+}

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ObjectMapperFactory.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ObjectMapperFactory.java
@@ -1,0 +1,56 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.server.rest;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+
+import javax.enterprise.inject.Produces;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Creates and configures an {@link ObjectMapper}.
+ */
+@Provider
+public class ObjectMapperFactory {
+
+  @Produces
+  public ObjectMapper createObjectMapper() {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    objectMapper.registerModule(new JaxbAnnotationModule());
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    AnnotationIntrospector jaxbIntrospector = new JaxbAnnotationIntrospector(objectMapper.getTypeFactory());
+    AnnotationIntrospector jacksonIntrospector = new JacksonAnnotationIntrospector();
+    AnnotationIntrospector pair = new AnnotationIntrospectorPair(jacksonIntrospector, jaxbIntrospector);
+    objectMapper.setAnnotationIntrospector(pair);
+
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    return objectMapper;
+  }
+}

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonJaxbJsonProvider.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonJaxbJsonProvider.java
@@ -1,0 +1,43 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.server.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import org.apache.directory.scim.spec.protocol.Constants;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Adds JacksonJaxbJsonProvider for custom MediaType {@code application/scim+json}.
+ */
+@Provider
+@Consumes(Constants.SCIM_CONTENT_TYPE)
+@Produces(Constants.SCIM_CONTENT_TYPE)
+public class ScimJacksonJaxbJsonProvider extends JacksonJaxbJsonProvider {
+
+  @Inject
+  public ScimJacksonJaxbJsonProvider(ObjectMapper objectMapper) {
+    super(objectMapper, DEFAULT_ANNOTATIONS);
+  }
+}

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimResourceHelper.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimResourceHelper.java
@@ -58,6 +58,7 @@ public final class ScimResourceHelper {
     clazzez.add(FilterParseExceptionMapper.class);
 
     clazzez.add(ObjectMapperContextResolver.class);
+    clazzez.add(DeserializerConfigurer.class);
 
     return clazzez;
   }

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/WebApplicationExceptionMapper.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/WebApplicationExceptionMapper.java
@@ -1,0 +1,47 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.server.rest;
+
+import org.apache.directory.scim.spec.protocol.Constants;
+import org.apache.directory.scim.spec.protocol.data.ErrorResponse;
+
+import javax.enterprise.inject.Alternative;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Produces(Constants.SCIM_CONTENT_TYPE)
+@Alternative
+public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
+
+  public Response toResponse(WebApplicationException e) {
+    ErrorResponse em = new ErrorResponse(Status.fromStatusCode(e.getResponse().getStatus()), e.getMessage());
+
+    Response response = em.toResponse();
+    response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
+
+    return response;
+  }
+}

--- a/scim-server/scim-server-common/src/main/resources/META-INF/beans.xml
+++ b/scim-server/scim-server-common/src/main/resources/META-INF/beans.xml
@@ -18,5 +18,10 @@ under the License.
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
        version="1.1" bean-discovery-mode="all">
-       
+
+  <!-- Not the cleanest way, but when using CXF, this alt class gets loaded before
+       edu.psu.swe.commons.jaxrs.exceptions.mappers.WebApplicationExceptionMapper  -->
+  <alternatives>
+    <class>org.apache.directory.scim.server.rest.WebApplicationExceptionMapper</class>
+  </alternatives>
 </beans>


### PR DESCRIPTION
Apache CXF handles ObjectMapper configuration differently then WildFly