### PR TITLE
Override Lombok Generated toString() Methods

### DIFF
--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/attribute/AttributeReference.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/attribute/AttributeReference.java
@@ -114,4 +114,7 @@ public class AttributeReference implements Serializable {
     return attributeBase;
   }
 
+  public String toString() {
+    return (this.urn != null ? this.urn + ":" : "") + this.attributeName + (this.subAttributeName != null ? "." + this.subAttributeName : "");
+  }
 }

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/attribute/AttributeReferenceListWrapper.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/attribute/AttributeReferenceListWrapper.java
@@ -21,6 +21,7 @@ package org.apache.directory.scim.spec.protocol.attribute;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -51,5 +52,9 @@ public class AttributeReferenceListWrapper {
     AttributeReferenceListWrapper wrapper = new AttributeReferenceListWrapper("");
     wrapper.attributeReferences = attributeReferences;
     return wrapper;
+  }
+
+  public String toString() {
+    return attributeReferences.stream().map(AttributeReference::toString).collect(Collectors.joining(","));
   }
 }


### PR DESCRIPTION
Jaxrs uses the lombok generated toString() method when serializing AttributeReferenceListWrapper as a query parameter. This is then parsed incorrectly by the server.