### PR TITLE
Making SelfIdResolver optional

### DIFF
--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
@@ -45,13 +45,13 @@ import lombok.extern.slf4j.Slf4j;
 public class SelfResourceImpl implements SelfResource {
 
   @Inject
-  private UserResource userResource;
+  UserResource userResource;
 
   @Inject
-  private Instance<SelfIdResolver> selfIdResolver;
+  Instance<SelfIdResolver> selfIdResolver;
 
   @Resource
-  private SessionContext sessionContext;
+  SessionContext sessionContext;
 
   @Override
   public Response getSelf(AttributeReferenceListWrapper attributes, AttributeReferenceListWrapper excludedAttributes) {
@@ -135,23 +135,5 @@ public class SelfResourceImpl implements SelfResource {
     }
 
     return selfIdResolver.get().resolveToInternalId(callerPrincipal);
-  }
-
-  // exposed for testing
-  SelfResourceImpl setSessionContext(SessionContext sessionContext) {
-    this.sessionContext = sessionContext;
-    return this;
-  }
-
-  // exposed for testing
-  SelfResourceImpl setSelfIdResolver(Instance<SelfIdResolver> selfIdResolver) {
-    this.selfIdResolver = selfIdResolver;
-    return this;
-  }
-
-  // exposed for testing
-  public SelfResourceImpl setUserResource(UserResource userResource) {
-    this.userResource = userResource;
-    return this;
   }
 }

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
@@ -45,10 +45,10 @@ import lombok.extern.slf4j.Slf4j;
 public class SelfResourceImpl implements SelfResource {
 
   @Inject
-  UserResource userResource;
+  private UserResource userResource;
 
   @Inject
-  Instance<SelfIdResolver> selfIdResolver;
+  private Instance<SelfIdResolver> selfIdResolver;
 
   @Resource
   private SessionContext sessionContext;
@@ -125,13 +125,33 @@ public class SelfResourceImpl implements SelfResource {
     Principal callerPrincipal = sessionContext.getCallerPrincipal();
 
     if (callerPrincipal != null) {
-      log.info("Resolved SelfResource principal to : {}", callerPrincipal.getName());
+      log.debug("Resolved SelfResource principal to : {}", callerPrincipal.getName());
     } else {
       throw new UnableToResolveIdException(Status.UNAUTHORIZED, "Unauthorized");
     }
 
-    String internalId = selfIdResolver.get().resolveToInternalId(callerPrincipal);
-    return internalId;
+    if (selfIdResolver.isUnsatisfied()) {
+      throw new UnableToResolveIdException(Status.NOT_IMPLEMENTED, "Caller SelfIdResolver not available");
+    }
+
+    return selfIdResolver.get().resolveToInternalId(callerPrincipal);
   }
 
+  // exposed for testing
+  SelfResourceImpl setSessionContext(SessionContext sessionContext) {
+    this.sessionContext = sessionContext;
+    return this;
+  }
+
+  // exposed for testing
+  SelfResourceImpl setSelfIdResolver(Instance<SelfIdResolver> selfIdResolver) {
+    this.selfIdResolver = selfIdResolver;
+    return this;
+  }
+
+  // exposed for testing
+  public SelfResourceImpl setUserResource(UserResource userResource) {
+    this.userResource = userResource;
+    return this;
+  }
 }

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
@@ -24,12 +24,12 @@ import java.security.Principal;
 import javax.annotation.Resource;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateless;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.directory.scim.server.exception.UnableToResolveIdException;
-import org.apache.directory.scim.server.provider.ProviderRegistry;
 import org.apache.directory.scim.server.provider.SelfIdResolver;
 import org.apache.directory.scim.spec.protocol.SelfResource;
 import org.apache.directory.scim.spec.protocol.UserResource;
@@ -45,13 +45,10 @@ import lombok.extern.slf4j.Slf4j;
 public class SelfResourceImpl implements SelfResource {
 
   @Inject
-  ProviderRegistry providerRegistry;
-
-  @Inject
   UserResource userResource;
 
   @Inject
-  SelfIdResolver selfIdResolver;
+  Instance<SelfIdResolver> selfIdResolver;
 
   @Resource
   private SessionContext sessionContext;
@@ -133,7 +130,7 @@ public class SelfResourceImpl implements SelfResource {
       throw new UnableToResolveIdException(Status.UNAUTHORIZED, "Unauthorized");
     }
 
-    String internalId = selfIdResolver.resolveToInternalId(callerPrincipal);
+    String internalId = selfIdResolver.get().resolveToInternalId(callerPrincipal);
     return internalId;
   }
 

--- a/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/rest/SelfResourceImplTest.java
+++ b/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/rest/SelfResourceImplTest.java
@@ -1,0 +1,75 @@
+package org.apache.directory.scim.server.rest;
+
+import org.apache.directory.scim.server.exception.UnableToResolveIdException;
+import org.apache.directory.scim.server.provider.SelfIdResolver;
+import org.apache.directory.scim.spec.protocol.UserResource;
+import org.apache.directory.scim.spec.protocol.data.ErrorResponse;
+import org.apache.directory.scim.spec.protocol.exception.ScimException;
+import org.junit.Test;
+
+import javax.ejb.SessionContext;
+import javax.enterprise.inject.Instance;
+import javax.ws.rs.core.Response;
+import java.security.Principal;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class SelfResourceImplTest {
+
+  @Test
+  public void noSelfIdResolverTest() {
+
+    Principal principal = mock(Principal.class);
+    SessionContext sessionContext = mock(SessionContext.class);
+    Instance selfIdResolverInstance = mock(Instance.class);
+
+    when(sessionContext.getCallerPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn("test-user");
+    when(selfIdResolverInstance.isUnsatisfied()).thenReturn(true);
+
+    SelfResourceImpl selfResource = new SelfResourceImpl()
+        .setSelfIdResolver(selfIdResolverInstance)
+        .setSessionContext(sessionContext);
+
+    Response response = selfResource.getSelf(null, null);
+    assertThat(response.getEntity(), instanceOf(ErrorResponse.class));
+    List<String> messages = ((ErrorResponse)response.getEntity()).getErrorMessageList();
+    assertThat(messages, hasItem("Caller SelfIdResolver not available"));
+    assertThat(messages, hasSize(1));
+  }
+
+  @Test
+  public void withSelfIdResolverTest() throws UnableToResolveIdException, ScimException {
+
+    String internalId = "test-user-resolved";
+    Principal principal = mock(Principal.class);
+    SessionContext sessionContext = mock(SessionContext.class);
+    Instance selfIdResolverInstance = mock(Instance.class);
+    SelfIdResolver selfIdResolver = mock(SelfIdResolver.class);
+    UserResource userResource = mock(UserResource.class);
+    Response mockResponse = mock(Response.class);
+
+    when(sessionContext.getCallerPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn("test-user");
+    when(selfIdResolverInstance.isUnsatisfied()).thenReturn(false);
+    when(selfIdResolverInstance.get()).thenReturn(selfIdResolver);
+    when(selfIdResolver.resolveToInternalId(principal)).thenReturn(internalId);
+    when(userResource.getById(internalId, null, null)).thenReturn(mockResponse);
+
+    SelfResourceImpl selfResource = new SelfResourceImpl()
+        .setSelfIdResolver(selfIdResolverInstance)
+        .setSessionContext(sessionContext)
+        .setUserResource(userResource);
+
+    // the response is just a passed along from the UserResource, so just validate it is the same instance.
+    assertThat(selfResource.getSelf(null, null), sameInstance(mockResponse));
+  }
+}

--- a/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/rest/SelfResourceImplTest.java
+++ b/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/rest/SelfResourceImplTest.java
@@ -35,9 +35,9 @@ public class SelfResourceImplTest {
     when(principal.getName()).thenReturn("test-user");
     when(selfIdResolverInstance.isUnsatisfied()).thenReturn(true);
 
-    SelfResourceImpl selfResource = new SelfResourceImpl()
-        .setSelfIdResolver(selfIdResolverInstance)
-        .setSessionContext(sessionContext);
+    SelfResourceImpl selfResource = new SelfResourceImpl();
+    selfResource.selfIdResolver = selfIdResolverInstance;
+    selfResource.sessionContext = sessionContext;
 
     Response response = selfResource.getSelf(null, null);
     assertThat(response.getEntity(), instanceOf(ErrorResponse.class));
@@ -64,10 +64,10 @@ public class SelfResourceImplTest {
     when(selfIdResolver.resolveToInternalId(principal)).thenReturn(internalId);
     when(userResource.getById(internalId, null, null)).thenReturn(mockResponse);
 
-    SelfResourceImpl selfResource = new SelfResourceImpl()
-        .setSelfIdResolver(selfIdResolverInstance)
-        .setSessionContext(sessionContext)
-        .setUserResource(userResource);
+    SelfResourceImpl selfResource = new SelfResourceImpl();
+    selfResource.selfIdResolver = selfIdResolverInstance;
+    selfResource.sessionContext = sessionContext;
+    selfResource.userResource = userResource;
 
     // the response is just a passed along from the UserResource, so just validate it is the same instance.
     assertThat(selfResource.getSelf(null, null), sameInstance(mockResponse));


### PR DESCRIPTION
This is object is not used in required for basic usage

(trying to simplify the code needed for examples)