### PR TITLE
Move Jackson configuration into a Factory and Provider

### DIFF
--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ObjectMapperFactory.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ObjectMapperFactory.java
@@ -1,0 +1,72 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.server.rest;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import org.apache.directory.scim.server.schema.Registry;
+import org.apache.directory.scim.spec.resources.ScimResource;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Creates and configures an {@link ObjectMapper} used for {@code application/scim+json} parsing.
+ */
+@Provider
+public class ObjectMapperFactory {
+
+  private final Registry registry;
+
+  @Inject
+  public ObjectMapperFactory(Registry registry) {
+    this.registry = registry;
+  }
+
+  @Produces
+  public ObjectMapper createObjectMapper() {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    objectMapper.registerModule(new JaxbAnnotationModule());
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    AnnotationIntrospector jaxbIntrospector = new JaxbAnnotationIntrospector(objectMapper.getTypeFactory());
+    AnnotationIntrospector jacksonIntrospector = new JacksonAnnotationIntrospector();
+    AnnotationIntrospector pair = new AnnotationIntrospectorPair(jacksonIntrospector, jaxbIntrospector);
+    objectMapper.setAnnotationIntrospector(pair);
+
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(ScimResource.class, new ScimResourceDeserializer(registry, objectMapper));
+    objectMapper.registerModule(module);
+
+    return objectMapper;
+  }
+}

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonJaxbJsonProvider.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonJaxbJsonProvider.java
@@ -26,7 +26,6 @@ import org.apache.directory.scim.spec.protocol.Constants;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
-import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
 /**
@@ -35,18 +34,10 @@ import javax.ws.rs.ext.Provider;
 @Provider
 @Consumes(Constants.SCIM_CONTENT_TYPE)
 @Produces(Constants.SCIM_CONTENT_TYPE)
-public class ScimJacksonJaxbJsonProvider extends JacksonJaxbJsonProvider implements ContextResolver<ObjectMapper> {
-
-  private final ObjectMapper objectMapper;
+public class ScimJacksonJaxbJsonProvider extends JacksonJaxbJsonProvider {
 
   @Inject
   public ScimJacksonJaxbJsonProvider(ObjectMapper objectMapper) {
     super(objectMapper, DEFAULT_ANNOTATIONS);
-    this.objectMapper = objectMapper;
-  }
-
-  @Override
-  public ObjectMapper getContext(Class<?> type) {
-    return objectMapper;
   }
 }

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonJaxbJsonProvider.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonJaxbJsonProvider.java
@@ -6,7 +6,7 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
- 
+
 * http://www.apache.org/licenses/LICENSE-2.0
 
 * Unless required by applicable law or agreed to in writing,
@@ -19,23 +19,30 @@
 
 package org.apache.directory.scim.server.rest;
 
-import javax.inject.Inject;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import org.apache.directory.scim.spec.protocol.Constants;
 
-import org.apache.directory.scim.server.schema.Registry;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
 
 /**
- * @deprecated Use {@link ScimJacksonJaxbJsonProvider} instead.
+ * Adds JacksonJaxbJsonProvider for custom MediaType {@code application/scim+json}.
  */
-@Deprecated
-public class ObjectMapperContextResolver extends edu.psu.swe.commons.jaxrs.server.ObjectMapperContextResolver {
+@Provider
+@Consumes(Constants.SCIM_CONTENT_TYPE)
+@Produces(Constants.SCIM_CONTENT_TYPE)
+public class ScimJacksonJaxbJsonProvider extends JacksonJaxbJsonProvider implements ContextResolver<ObjectMapper> {
 
-  private ObjectMapper objectMapper;
+  private final ObjectMapper objectMapper;
 
   @Inject
-  public ObjectMapperContextResolver(Registry registry) {
-    objectMapper = new ObjectMapperFactory(registry).createObjectMapper();
+  public ScimJacksonJaxbJsonProvider(ObjectMapper objectMapper) {
+    super(objectMapper, DEFAULT_ANNOTATIONS);
+    this.objectMapper = objectMapper;
   }
 
   @Override

--- a/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimResourceHelper.java
+++ b/scim-server/scim-server-common/src/main/java/org/apache/directory/scim/server/rest/ScimResourceHelper.java
@@ -57,7 +57,8 @@ public final class ScimResourceHelper {
     clazzez.add(UserResourceImpl.class);
     clazzez.add(FilterParseExceptionMapper.class);
 
-    clazzez.add(ObjectMapperContextResolver.class);
+    // handle MediaType of application/scim+json
+    clazzez.add(ScimJacksonJaxbJsonProvider.class);
 
     return clazzez;
   }

--- a/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/provider/UpdateRequestTest.java
+++ b/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/provider/UpdateRequestTest.java
@@ -35,6 +35,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.directory.scim.server.rest.ObjectMapperFactory;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -49,7 +50,6 @@ import org.mockito.junit.MockitoRule;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.directory.scim.server.rest.ObjectMapperContextResolver;
 import org.apache.directory.scim.server.schema.Registry;
 import org.apache.directory.scim.server.utility.ExampleObjectExtension;
 import org.apache.directory.scim.server.utility.Subobject;
@@ -993,8 +993,7 @@ public class UpdateRequestTest {
   }
 
   private ScimUser copy(ScimUser scimUser) throws IOException {
-    ObjectMapperContextResolver omcr = new ObjectMapperContextResolver();
-    ObjectMapper objMapper = omcr.getContext(null);
+    ObjectMapper objMapper = new ObjectMapperFactory(registry).createObjectMapper();
     String json = objMapper.writeValueAsString(scimUser);
     return objMapper.readValue(json, ScimUser.class);
   }


### PR DESCRIPTION
Deprecates ObjectMapperContextResolver, to be replaced with portable ScimJacksonJaxbJsonProvider

fixes: #14 