### PR TITLE
Remove extensions for which no attributes have been requested.

### DIFF
--- a/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/utility/AttributeUtilTest.java
+++ b/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/utility/AttributeUtilTest.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Before;

--- a/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/utility/AttributeUtilTest.java
+++ b/scim-server/scim-server-common/src/test/java/org/apache/directory/scim/server/utility/AttributeUtilTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -167,7 +168,7 @@ public class AttributeUtilTest {
     
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
     
-    // TODO Assertions.assertThat(extension).isNull();
+    Assertions.assertThat(extension).as("%s should have been removed from extensions", EnterpriseExtension.URN).isNull();
   }
   
   @Test
@@ -196,8 +197,8 @@ public class AttributeUtilTest {
 
     
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-    
-    // TODO Assertions.assertThat(extension).isNull();
+
+    Assertions.assertThat(extension).as("%s should have been removed from extensions", EnterpriseExtension.URN).isNull();
   }
   
   @Test


### PR DESCRIPTION
Extensions that are not requested in the list of attributes in a request will be removed from the response.