### PR TITLE
PennSt Bug #67 - PatchOperationPathAdapter marshaller does not pass …

### DIFF
--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/data/PatchOperationPathAdapter.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/data/PatchOperationPathAdapter.java
@@ -28,7 +28,7 @@ public class PatchOperationPathAdapter extends XmlAdapter<String, PatchOperation
     if (v == null) {
       return null;
     }
-    return new PatchOperationPath();
+    return new PatchOperationPath(v);
   }
 
   @Override


### PR DESCRIPTION
…serialized information into object constructor.