### PR TITLE
Bulk dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,12 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
 
-    <version.jackson>2.10.1</version.jackson>
-    <version.lombok>1.18.10</version.lombok>
-    <version.lombok.plugin>${version.lombok}.0</version.lombok.plugin>
+    <version.jackson>2.13.2.1</version.jackson>
+    <version.lombok>1.18.22</version.lombok>
+    <version.lombok.plugin>1.18.20.0</version.lombok.plugin>
     <version.restfuse>1.2.0</version.restfuse>
+    <version.slf4j>1.7.36</version.slf4j>
+    <version.antlr4>4.5.3</version.antlr4>
   </properties>
 
   <modules>
@@ -142,7 +144,7 @@
       <dependency>
         <groupId>edu.psu.swe.commons</groupId>
         <artifactId>commons-jaxrs</artifactId>
-        <version>1.40</version>
+        <version>1.41.0</version>
       </dependency>
       <dependency>
         <groupId>javax</groupId>
@@ -153,12 +155,12 @@
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.1</version>
+        <version>2.3.1</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>
@@ -168,12 +170,12 @@
       <dependency>
         <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se</artifactId>
-        <version>2.2.11.Final</version>
+        <version>2.4.8.Final</version>
       </dependency>
       <dependency>
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
-        <version>2.32</version>
+        <version>2.33</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>
@@ -184,7 +186,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.5.0</version>
+        <version>5.8.2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -199,20 +201,20 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>9.4.8.v20180619</version>
+        <version>9.4.45.v20220203</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>5.1.3.Final</version>
+        <version>5.4.3.Final</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>javax.el</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-b12</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -224,47 +226,60 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jackson-provider</artifactId>
-        <version>3.0.11.Final</version>
+        <version>3.15.3.Final</version>
         <scope>test</scope>
+      </dependency>
+      <!-- Guava is a transitive dep, forcing a newer version to avoid older vulns -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>31.0.1-android</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.12</version>
+        <version>${version.slf4j}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>1.7.12</version>
+        <version>${version.slf4j}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.21.0</version>
+        <version>4.4.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>2.21.0</version>
+        <version>4.4.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.3.0</version>
+        <version>3.9.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
+        <!-- RestFuse is no longer maintained -->
         <groupId>com.restfuse</groupId>
         <artifactId>com.eclipsesource.restfuse</artifactId>
         <version>${version.restfuse}</version>
       </dependency>
+      <!-- Update the version of junit restfuse depends on -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+      </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>java-hamcrest</artifactId>
-        <version>2.0.0.0</version>
+        <artifactId>hamcrest</artifactId>
+        <version>2.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -282,7 +297,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.3</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -300,7 +315,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.12</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>rao</serverId>
@@ -330,7 +345,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>5.3.0</version>
+          <version>7.0.4</version>
           <configuration>
             <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
             <suppressionFile>${session.executionRootDirectory}/src/owasp/suppression.xml</suppressionFile>
@@ -435,7 +450,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.12</version>
+          <version>0.13</version>
           <configuration>
             <excludes>
               <exclude>**/README.md</exclude>
@@ -447,7 +462,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.22.0</version>
+            <version>3.0.0-M5</version>
             <configuration>
               <!-- parent pom overrides the default, so we MUST set the jacoco argline directly -->
               <argLine>@{jacoco.argline}</argLine>
@@ -456,7 +471,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.5</version>
+            <version>0.8.7</version>
           </plugin>
       </plugins>
     </pluginManagement>
@@ -493,7 +508,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.14.2</version>
+            <version>0.39.1</version>
             <configuration>
               <skip>true</skip>
             </configuration>
@@ -526,7 +541,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.14.2</version>
+            <version>0.39.1</version>
             <configuration>
               <skip>true</skip>
             </configuration>
@@ -554,7 +569,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/scim-server/scim-server-common/pom.xml
+++ b/scim-server/scim-server-common/pom.xml
@@ -91,7 +91,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-jaxrs</artifactId>
-			<version>1.6.0</version>
+			<version>1.6.6</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -88,7 +88,7 @@
 	<dependency>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-runtime</artifactId>
-		<version>4.5.3</version>
+		<version>${version.antlr4}</version>
 	</dependency>
 </dependencies>
 
@@ -97,7 +97,7 @@
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>
-				<version>4.5.3</version>
+				<version>${version.antlr4}</version>
 				<executions>
 					<execution>
 						<goals>

--- a/scim-spec/scim-spec-schema/pom.xml
+++ b/scim-spec/scim-spec-schema/pom.xml
@@ -75,12 +75,12 @@
 	<dependency>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-runtime</artifactId>
-		<version>4.5.3</version>
+		<version>${version.antlr4}</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.commons</groupId>
 		<artifactId>commons-lang3</artifactId>
-		<version>3.7</version>
+		<version>3.12.0</version>
 	</dependency>
 	<dependency>
 		<groupId>org.slf4j</groupId>
@@ -94,7 +94,7 @@
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>
-				<version>4.5.3</version>
+				<version>${version.antlr4}</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
- Lombok 1.18.22
- slf4j 1.7.36
- jackson 2.13.2.1
- javax.ws.rs-api 2.1.1
- commons-jaxrs 1.41
- jaxb-api 2.3.1
- weld 2.4.8
- args4j 2.33
- junit 5.8.2
- jetty 9.4.48.v20220203
- hibernate-validator 5.4.3
- javax.el 3.0.1-b12
- resteasy-jackson-provider 3.12.3
- guava 31.0.1
- mockito 4.4.0
- assertj 3.9.1
- hamcrest 2.2

Build Plugin updates
- buildnumber-maven-plugin 3.0.0
- nexus-staging-maven-plugin 1.6.12
- dependency-check-maven 7.0.4
- apache-rat-plugin 0.13
- maven- surefire-plugin 3.0.0-M5
- jacoco-maven-plugin 0.8.7
- docker-maven-plugin 0.39.1
- maven-gpg-plugin 3.0.1
- swagger-jaxrs 1.6.6
- commons-lang3 3.12.0
