### PR TITLE
Adds ScimAttribute annotation to the fields in the Meta class

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -26,6 +26,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.annotation.ScimExtensionType;
+import org.apache.directory.scim.spec.annotation.ScimResourceType;
 import org.apache.directory.scim.spec.exception.InvalidExtensionException;
 import org.apache.directory.scim.spec.extension.ScimExtensionRegistry;
 import org.apache.directory.scim.spec.json.ObjectMapperFactory;
@@ -83,6 +84,11 @@ public abstract class ScimResource extends BaseResource implements Serializable 
   public ScimResource(String urn) {
     super(urn);
     this.baseUrn = urn;
+
+    ScimResourceType resourceTypeAnnotation = getClass().getAnnotation(ScimResourceType.class);
+    if (resourceTypeAnnotation != null) {
+      this.meta = new Meta().setResourceType(resourceTypeAnnotation.id());
+    }
   }
 
   /**

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
@@ -31,6 +31,7 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.apache.directory.scim.spec.adapter.LocalDateTimeAdapter;
 import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
 
 /**
  * Defines the structure of the meta attribute for all SCIM resources as defined
@@ -49,20 +50,25 @@ public class Meta implements Serializable {
 
   @XmlElement
   @Size(min = 1)
+  @ScimAttribute(description = "The name of the resource type of the resource.")
   String resourceType;
   
   @XmlElement
   @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
+  @ScimAttribute(description = "The DateTime that the resource was added to the service provider.")
   LocalDateTime created;
   
   @XmlElement
   @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
+  @ScimAttribute(description = "The most recent DateTime that the details of this resource were updated at the service provider.")
   LocalDateTime lastModified;
   
   @XmlElement
+  @ScimAttribute(description = "The URI of the resource being returned.")
   String location;
   
   @XmlElement
+  @ScimAttribute(description = "The version of the resource being returned.  This value must be the same as the entity-tag (ETag) HTTP response header")
   String version;
 
 }


### PR DESCRIPTION
Descriptions taken from the SCIM spec
The ScimResource constructor will attempt to set meta.resourceType when possible
