### PR TITLE
Adds FilterBuilder connivance methods

### DIFF
--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/FilterBuilder.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/FilterBuilder.java
@@ -5,12 +5,17 @@ import org.apache.directory.scim.spec.protocol.search.Filter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.function.UnaryOperator;
 
 public interface FilterBuilder {
 
   FilterBuilder and();
 
   FilterBuilder and(FilterExpression fe1);
+
+  default FilterBuilder and(UnaryOperator<FilterBuilder> filter) {
+    return and(filter.apply(FilterBuilder.create()).build());
+  }
 
   default FilterBuilder and(Filter filter) {
     return and(filter.getExpression());
@@ -22,6 +27,10 @@ public interface FilterBuilder {
     return and(left.getExpression(), right.getExpression());
   }
 
+  default FilterBuilder and(UnaryOperator<FilterBuilder> left, UnaryOperator<FilterBuilder> right) {
+    return and(left.apply(FilterBuilder.create()).build(), right.apply(FilterBuilder.create()).build());
+  }
+
   FilterBuilder or();
 
   FilterBuilder or(FilterExpression fe1);
@@ -30,10 +39,17 @@ public interface FilterBuilder {
     return or(filter.getExpression());
   }
 
+  default FilterBuilder or(UnaryOperator<FilterBuilder> filter) {
+    return or(filter.apply(FilterBuilder.create()).build());
+  }
+
   FilterBuilder or(FilterExpression left, FilterExpression right);
 
   default FilterBuilder or(Filter left, Filter right) {
     return or(left.getExpression(), right.getExpression());
+  }
+  default FilterBuilder or(UnaryOperator<FilterBuilder> left, UnaryOperator<FilterBuilder> right) {
+    return or(left.apply(FilterBuilder.create()).build(), right.apply(FilterBuilder.create()).build());
   }
 
   FilterBuilder equalTo(String key, String value);
@@ -102,15 +118,25 @@ public interface FilterBuilder {
 
   FilterBuilder contains(String key, String value);
 
+  FilterBuilder present(String key);
+
   FilterBuilder not(FilterExpression fe);
 
   default FilterBuilder not(Filter filter) {
     return not(filter.getExpression());
   }
 
-  FilterBuilder attributeHas(String attribute, FilterExpression filter) throws FilterParseException;
+  default FilterBuilder not(UnaryOperator<FilterBuilder> filter) {
+    return not(filter.apply(FilterBuilder.create()).build());
+  }
 
-  default FilterBuilder attributeHas(String attribute, Filter filter) throws FilterParseException {
+  FilterBuilder attributeHas(String attribute, FilterExpression filter);
+
+  default FilterBuilder attributeHas(String attribute, UnaryOperator<FilterBuilder> filter) {
+    return attributeHas(attribute, filter.apply(FilterBuilder.create()).build());
+  }
+
+  default FilterBuilder attributeHas(String attribute, Filter filter) {
     return attributeHas(attribute, filter.getExpression());
   }
 

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/FilterComparisonFilterBuilder.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/FilterComparisonFilterBuilder.java
@@ -182,6 +182,16 @@ class FilterComparisonFilterBuilder extends ComplexLogicalFilterBuilder {
     }
 
     @Override
+    public FilterBuilder present(String key) {
+      AttributeReference ar = new AttributeReference(key);
+      FilterExpression filterExpression = new AttributePresentExpression(ar);
+
+      handleComparisonExpression(filterExpression);
+
+      return this;
+    }
+
+    @Override
     public <T extends Number> FilterBuilder greaterThan(String key, T value) {
       AttributeReference ar = new AttributeReference(key);
       FilterExpression filterExpression = new AttributeComparisonExpression(ar, CompareOperator.GT, value);
@@ -354,7 +364,7 @@ class FilterComparisonFilterBuilder extends ComplexLogicalFilterBuilder {
     }
 
     @Override
-    public FilterBuilder attributeHas(String attribute, FilterExpression expression) throws FilterParseException {
+    public FilterBuilder attributeHas(String attribute, FilterExpression expression) {
       handleComparisonExpression(ValuePathExpression.fromFilterExpression(attribute, expression));
 
       return this;

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/FilterExpression.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/FilterExpression.java
@@ -21,7 +21,7 @@ package org.apache.directory.scim.spec.protocol.filter;
 
 public interface FilterExpression {
   
-  public String toFilter();
+  String toFilter();
 
   void setAttributePath(String urn, String parentAttributeName);
 

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/ValuePathExpression.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/spec/protocol/filter/ValuePathExpression.java
@@ -37,13 +37,13 @@ public class ValuePathExpression implements FilterExpression {
     this.attributePath = attributePath;
   }
 
-  public static ValuePathExpression fromFilterExpression(AttributeReference attrRef, FilterExpression attributeExpression) throws FilterParseException {
+  public static ValuePathExpression fromFilterExpression(AttributeReference attrRef, FilterExpression attributeExpression) {
     ValuePathExpression vpe = new ValuePathExpression(attrRef, attributeExpression);
 
     return vpe;
   }
 
-  public static ValuePathExpression fromFilterExpression(String attribute, FilterExpression expression) throws FilterParseException {
+  public static ValuePathExpression fromFilterExpression(String attribute, FilterExpression expression) {
     AttributeReference attributeReference = new AttributeReference(attribute);
 
     return fromFilterExpression(attributeReference,  expression);

--- a/scim-spec/scim-spec-protocol/src/test/java/org/apache/directory/scim/spec/protocol/filter/FilterBuilderPresentTest.java
+++ b/scim-spec/scim-spec-protocol/src/test/java/org/apache/directory/scim/spec/protocol/filter/FilterBuilderPresentTest.java
@@ -1,0 +1,48 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ 
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.spec.protocol.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.directory.scim.spec.protocol.search.Filter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class FilterBuilderPresentTest {
+
+  @Test
+  public void testAttributePresent() throws FilterParseException {
+    Filter filter = FilterBuilder.create().present("address.streetAddress").build();
+    Filter expected = new Filter("address.streetAddress PR");
+    assertThat(filter).isEqualTo(expected);
+  }
+
+  @Test
+  public void testStartsWith()  throws FilterParseException {
+    Filter filter = FilterBuilder.create()
+      .present("address.streetAddress")
+      .and()
+      .equalTo("address.region", "CA")
+      .build();
+    Filter expected = new Filter("address.streetAddress PR AND address.region EQ \"CA\"");
+    assertThat(filter).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
Exposes `present` method FilterBuilder

Reduces verbosity of building complex filters

Was:

FilterBuilder.create().and(
        FilterBuilder.create().equalTo("key1", "value1").build(),
        FilterBuilder.create().equalTo("key2", "value2").build())
    .build()

Can now be written as:

FilterBuilder.create().and(
        filter -> filter.equalTo("key1", "value1"),
        filter -> filter.equalTo("key2", "value2"))
    .build()
