### PR TITLE
ScimJacksonProvider now handles extensions

### DIFF
--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/AttributeUtil.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/AttributeUtil.java
@@ -19,7 +19,6 @@
 
 package org.apache.directory.scim.server.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.directory.scim.server.exception.AttributeDoesNotExistException;
@@ -54,13 +53,8 @@ class AttributeUtil {
 
   SchemaRegistry schemaRegistry;
 
-  ObjectMapper objectMapper;
-
   AttributeUtil(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
-
-    // TODO move this to a CDI producer
-    objectMapper = new ObjectMapperFactory(schemaRegistry).createObjectMapper();
   }
 
   public <T extends ScimResource> T keepAlwaysAttributesForDisplay(T resource) throws AttributeException {

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/EtagGenerator.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/EtagGenerator.java
@@ -19,12 +19,13 @@
 
 package org.apache.directory.scim.server.rest;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.apache.directory.scim.spec.json.ObjectMapperFactory;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jdk.jfr.Name;
+import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.schema.Meta;
 
@@ -38,13 +39,7 @@ import java.util.Base64;
 @ApplicationScoped
 public class EtagGenerator {
 
-  private final ObjectMapper objectMapper;
-
-  public EtagGenerator() {
-    objectMapper = ObjectMapperFactory.getObjectMapper();
-    objectMapper.setSerializationInclusion(Include.NON_NULL);
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-  }
+  private final ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
 
   public EntityTag generateEtag(ScimResource resource) throws JsonProcessingException, NoSuchAlgorithmException, UnsupportedEncodingException {
 

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonXmlBindJsonProvider.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonXmlBindJsonProvider.java
@@ -20,7 +20,8 @@
 package org.apache.directory.scim.server.rest;
 
 import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
-import org.apache.directory.scim.spec.json.ObjectMapperFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.protocol.Constants;
 
 import jakarta.inject.Inject;
@@ -34,10 +35,12 @@ import jakarta.ws.rs.ext.Provider;
 @Provider
 @Consumes(Constants.SCIM_CONTENT_TYPE)
 @Produces(Constants.SCIM_CONTENT_TYPE)
+@ApplicationScoped
 public class ScimJacksonXmlBindJsonProvider extends JacksonXmlBindJsonProvider {
 
   @Inject
-  public ScimJacksonXmlBindJsonProvider() {
-    super(ObjectMapperFactory.getObjectMapper(), DEFAULT_ANNOTATIONS);
+  public ScimJacksonXmlBindJsonProvider(SchemaRegistry schemaRegistry) {
+    super(ObjectMapperFactory.createObjectMapper(schemaRegistry), DEFAULT_ANNOTATIONS);
+
   }
 }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/CustomExtensionIT.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/CustomExtensionIT.java
@@ -1,0 +1,42 @@
+package org.apache.directory.scim.server.it;
+
+import org.apache.directory.scim.compliance.junit.EmbeddedServerExtension;
+import org.apache.directory.scim.compliance.tests.ScimpleITSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.Matchers.*;
+
+@ExtendWith(EmbeddedServerExtension.class)
+public class CustomExtensionIT extends ScimpleITSupport {
+
+  @Test
+  public void extensionDataTest() {
+
+    String body = "{" +
+      "\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\"]," +
+      "\"userName\":\"test@example.com\"," +
+      "\"name\":{" +
+        "\"givenName\":\"Tester\"," +
+        "\"familyName\":\"McTest\"}," +
+      "\"emails\":[{" +
+        "\"primary\":true," +
+        "\"value\":\"test@example.com\"," +
+        "\"type\":\"work\"}]," +
+      "\"displayName\":\"Tester McTest\"," +
+      "\"active\":true," +
+      "\"urn:mem:params:scim:schemas:extension:LuckyNumberExtension\": {" +
+        "\"luckyNumber\": \"1234\"}" + // This value can be a number or string, but will always be a number in the body
+      "}";
+
+    post("/Users", body)
+      .statusCode(201)
+      .body(
+        "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:User", "urn:mem:params:scim:schemas:extension:LuckyNumberExtension"),
+        "active", is(true),
+        "id", not(emptyString()),
+        "'urn:mem:params:scim:schemas:extension:LuckyNumberExtension'", notNullValue(),
+        "'urn:mem:params:scim:schemas:extension:LuckyNumberExtension'.luckyNumber", is(1234)
+      );
+  }
+}

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
@@ -87,6 +87,8 @@ public class InMemoryUserService implements Repository<ScimUser> {
     email.setPrimary(true);
     user.setEmails(List.of(email));
 
+    user.addExtension(new LuckyNumberExtension().setLuckyNumber(DEFAULT_USER_LUCKY_NUMBER));
+
     users.put(user.getId(), user);
   }
 
@@ -174,6 +176,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
    */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
+    return List.of(LuckyNumberExtension.class);
   }
 }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/LuckyNumberExtension.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/LuckyNumberExtension.java
@@ -1,0 +1,61 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.server.it.testapp;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
+import org.apache.directory.scim.spec.annotation.ScimExtensionType;
+import org.apache.directory.scim.spec.resources.ScimExtension;
+import org.apache.directory.scim.spec.schema.Schema;
+
+/**
+ * Allows a User's lucky number to be passed as part of the User's entry via
+ * the SCIM protocol.
+ * 
+ * @author Chris Harm &lt;crh5255@psu.edu&gt;
+ */
+@XmlRootElement( name = "LuckyNumberExtension", namespace = "http://www.psu.edu/schemas/psu-scim" )
+@XmlAccessorType(XmlAccessType.NONE)
+@Data
+@ScimExtensionType(id = LuckyNumberExtension.SCHEMA_URN, description="Lucky Numbers", name="LuckyNumbers", required=true)
+public class LuckyNumberExtension implements ScimExtension {
+  
+  public static final String  SCHEMA_URN = "urn:mem:params:scim:schemas:extension:LuckyNumberExtension";
+
+  @ScimAttribute(returned=Schema.Attribute.Returned.DEFAULT, required=true)
+  @XmlElement
+  private long luckyNumber;
+  
+  /**
+   * Provides the URN associated with this extension which, as defined by the
+   * SCIM specification is the extension's unique identifier.
+   * 
+   * @return The extension's URN.
+   */
+  @Override
+  public String getUrn() {
+    return SCHEMA_URN;
+  }
+
+}

--- a/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
@@ -28,7 +28,6 @@ import org.apache.directory.scim.server.utility.ExampleObjectExtension;
 import org.apache.directory.scim.server.utility.ExampleObjectExtension.ComplexObject;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension.Manager;
-import org.apache.directory.scim.spec.json.ObjectMapperFactory;
 import org.apache.directory.scim.spec.phonenumber.PhoneNumberParseException;
 import org.apache.directory.scim.spec.filter.attribute.AttributeReference;
 import org.apache.directory.scim.spec.resources.Address;
@@ -62,16 +61,16 @@ public class AttributeUtilTest {
 
   AttributeUtil attributeUtil;
 
-  private ObjectMapper objectMapper;
+  final private ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
 
   @BeforeEach
   public void setup() {
     schemaRegistry = Mockito.mock(SchemaRegistry.class);
+
     attributeUtil = new AttributeUtil(schemaRegistry);
     Schema scimUserSchema = Schemas.schemaFor(ScimUser.class);
     Schema scimEnterpriseUserSchema = Schemas.schemaForExtension(EnterpriseExtension.class);
     Schema scimExampleSchema = Schemas.schemaForExtension(ExampleObjectExtension.class);
-
 
     Mockito.when(schemaRegistry.getBaseSchemaOfResourceType(ScimUser.RESOURCE_NAME)).thenReturn(scimUserSchema);
     Mockito.when(schemaRegistry.getSchema(ScimUser.SCHEMA_URI)).thenReturn(scimUserSchema);
@@ -79,11 +78,6 @@ public class AttributeUtilTest {
     Mockito.when(schemaRegistry.getSchema(ExampleObjectExtension.URN)).thenReturn(scimExampleSchema);
     Mockito.when(schemaRegistry.getAllSchemas()).thenReturn(Arrays.asList(scimUserSchema, scimEnterpriseUserSchema, scimExampleSchema));
     Mockito.when(schemaRegistry.getAllSchemaUrns()).thenReturn(new HashSet<>(Arrays.asList(ScimUser.SCHEMA_URI, EnterpriseExtension.URN, ExampleObjectExtension.URN)));
-
-    objectMapper = ObjectMapperFactory.getObjectMapper();
-    objectMapper.setSerializationInclusion(Include.NON_NULL);
-    objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-
   }
 
   @Test

--- a/scim-server/src/test/java/org/apache/directory/scim/server/rest/ObjectMapperFactoryTest.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/rest/ObjectMapperFactoryTest.java
@@ -42,7 +42,7 @@ public class ObjectMapperFactoryTest {
     ExampleObjectExtension extension = new ExampleObjectExtension().setValueDefault("test-value");
     resource.addExtension(extension);
 
-    ObjectMapper objectMapper = new ObjectMapperFactory(schemaRegistry).createObjectMapper();
+    ObjectMapper objectMapper = ObjectMapperFactory.createObjectMapper(schemaRegistry);
     String json = objectMapper.writeValueAsString(resource);
 
     ScimResource actual = objectMapper.readValue(json, ScimResource.class);

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ObjectMapperFactory.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ObjectMapperFactory.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.directory.scim.spec.json;
+package org.apache.directory.scim.spec;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/resources/PhoneNumberJsonTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/resources/PhoneNumberJsonTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.directory.scim.spec.json.ObjectMapperFactory;
+import org.apache.directory.scim.spec.ObjectMapperFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,9 +39,7 @@ public class PhoneNumberJsonTest {
     ObjectMapper objectMapper = getObjectMapper();
     
     String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(phoneNumber);
-    
-    log.info(json);
-    
+
     PhoneNumber readValue = objectMapper.readValue(json, PhoneNumber.class);
     
     assertEquals(phoneNumber.getNumber(), readValue.getNumber());
@@ -65,5 +63,4 @@ public class PhoneNumberJsonTest {
     objectMapper.setSerializationInclusion(Include.NON_NULL);
     return objectMapper;
   }
-  
 }

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemaTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemaTest.java
@@ -20,7 +20,7 @@
 package org.apache.directory.scim.spec.schema;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.directory.scim.spec.json.ObjectMapperFactory;
+import org.apache.directory.scim.spec.ObjectMapperFactory;
 import org.apache.directory.scim.spec.schema.Schema.Attribute;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -67,6 +67,7 @@ public class SchemaTest {
       "schemas/urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig.json",
       "schemas/urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.json"
   })
+
   public void testUnmarshallingProvidedSchemas(String schemaFileName) {
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     InputStream inputStream = classLoader.getResourceAsStream(schemaFileName);


### PR DESCRIPTION
Reducing the places an ObjectMapper can be configured.
There are two configurations that are needed.
* _generic_ jakarta and jackson annotation processing
* SCIM resources using extension parsing (requires access to SchemaRegistry)

Added IT to ensure this works end-to-end
