### PR TITLE
Set version to 1.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.apache.directory.scim</groupId>
   <artifactId>scim-parent</artifactId>
-  <version>2.23-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SCIM - Parent</name>
   <description>Apache Directory SCIMple - JavaEE implementation of the SCIM version 2.0 specification (RFC7642, RFC7643 and RFC7644)</description>
@@ -117,17 +117,17 @@
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-protocol</artifactId>
-        <version>2.23-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-spec-schema</artifactId>
-        <version>2.23-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-core</artifactId>
-        <version>2.23-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
@@ -137,17 +137,17 @@
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-server</artifactId>
-        <version>2.23-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-client</artifactId>
-        <version>2.23-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.scim</groupId>
         <artifactId>scim-compliance-tests</artifactId>
-        <version>2.23-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim-client</artifactId>
   <name>SCIM - Client</name>

--- a/scim-compliance-tests/pom.xml
+++ b/scim-compliance-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-tests</artifactId>

--- a/scim-core/pom.xml
+++ b/scim-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-core</artifactId>

--- a/scim-coverage/pom.xml
+++ b/scim-coverage/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-test-coverage</artifactId>

--- a/scim-server-examples/scim-server-jersey/pom.xml
+++ b/scim-server-examples/scim-server-jersey/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/scim-server-examples/scim-server-memory/pom.xml
+++ b/scim-server-examples/scim-server-memory/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server</artifactId>

--- a/scim-spec/pom.xml
+++ b/scim-spec/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-spec</artifactId>

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-spec</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
 	<artifactId>scim-spec-protocol</artifactId>

--- a/scim-spec/scim-spec-schema/pom.xml
+++ b/scim-spec/scim-spec-schema/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-spec</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
 	<artifactId>scim-spec-schema</artifactId>

--- a/scim-tools/pom.xml
+++ b/scim-tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.directory.scim</groupId>
     <artifactId>scim-parent</artifactId>
-    <version>2.23-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools</artifactId>


### PR DESCRIPTION
The previous version 2.23 reflected the version that PennState/scim-identity used, that project has different coordinates, so the version can be reset to v1
