### PR TITLE
Return a 501 (not implemented) status code when a Repository is not found

### DIFF
--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/ScimExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/ScimExceptionMapper.java
@@ -35,9 +35,7 @@ public class ScimExceptionMapper implements ExceptionMapper<ScimException> {
 
   @Override
   public Response toResponse(ScimException e) {
-    ErrorResponse errorResponse = new ErrorResponse(e.getStatus(), e.getMessage());
-
-    Response response = errorResponse.toResponse();
+    Response response = e.getError().toResponse();
     response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
 
     return response;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -103,7 +103,7 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
   Repository<T> getRepositoryInternal() throws ScimException {
     Repository<T> repository = getRepository();
     if (repository == null) {
-      throw new ScimException(Status.INTERNAL_SERVER_ERROR, "Provider not defined");
+      throw new ScimException(Status.NOT_IMPLEMENTED, "Provider not defined");
     }
     return repository;
   }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImplTest.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImplTest.java
@@ -197,6 +197,22 @@ public class BaseResourceTypeResourceImplTest {
     assertThat(exception.getError().getDetail(), is("Cannot include both attributes and excluded attributes in a single request"));
   }
 
+  @Test
+  public void repositoryNotImplemented() throws ScimException {
+    // given
+    @SuppressWarnings("rawtypes")
+    BaseResourceTypeResourceImpl baseResourceImpl = Mockito.mock(BaseResourceTypeResourceImpl.class);
+    when(baseResourceImpl.getRepository()).thenReturn(null);
+    when(baseResourceImpl.getRepositoryInternal()).thenCallRealMethod();
+
+    // when
+    ScimException exception = assertThrows(ScimException.class, baseResourceImpl::getRepositoryInternal);
+
+    // then
+    assertEquals(exception.getStatus(), Status.NOT_IMPLEMENTED);
+    assertThat(exception.getError().getDetail(), is("Provider not defined"));
+  }
+
   private ScimUser getScimUser() throws PhoneNumberParseException {
     ScimUser user = new ScimUser();
 

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/exception/ScimException.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/exception/ScimException.java
@@ -30,8 +30,8 @@ import lombok.EqualsAndHashCode;
 public class ScimException extends Exception {
 
   private static final long serialVersionUID = 3643485564325176463L;
-  private ErrorResponse error;
-  private Status status;
+  private final ErrorResponse error;
+  private final Status status;
 
   public ScimException(Status status, String message, Throwable cause) {
     super(message, cause);


### PR DESCRIPTION
ScimExceptionMapper now _correctly_ uses the ErrorResponse object from the ScimException instead of creating a new one and dropping the detail message
