### PR TITLE
All ExceptionMappers extend common base class

### DIFF
--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/BaseScimExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/BaseScimExceptionMapper.java
@@ -1,0 +1,22 @@
+package org.apache.directory.scim.server.exception;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.directory.scim.protocol.Constants;
+import org.apache.directory.scim.protocol.data.ErrorResponse;
+
+@Slf4j
+abstract class BaseScimExceptionMapper<E extends Throwable> implements ExceptionMapper<E> {
+
+  protected abstract ErrorResponse errorResponse(E throwable);
+
+  @Override
+  public Response toResponse(E throwable) {
+    Response response = errorResponse(throwable).toResponse();
+    log.warn("Returning error status: {}", response.getStatus(), throwable);
+    response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
+    return response;
+  }
+}

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/FilterParseExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/FilterParseExceptionMapper.java
@@ -19,21 +19,23 @@
 
 package org.apache.directory.scim.server.exception;
 
-import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
-import jakarta.ws.rs.ext.ExceptionMapper;
 
+import jakarta.ws.rs.ext.Provider;
+import org.apache.directory.scim.protocol.Constants;
 import org.apache.directory.scim.protocol.ErrorMessageType;
 import org.apache.directory.scim.protocol.data.ErrorResponse;
 import org.apache.directory.scim.spec.filter.FilterParseException;
 
-public class FilterParseExceptionMapper implements ExceptionMapper<FilterParseException> {
+@Provider
+@Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
+public class FilterParseExceptionMapper extends BaseScimExceptionMapper<FilterParseException> {
 
   @Override
-  public Response toResponse(FilterParseException exception) {
-    ErrorResponse er = new ErrorResponse(Status.BAD_REQUEST, exception.getMessage());
-    er.setScimType(ErrorMessageType.INVALID_FILTER);
-    return er.toResponse();
+  protected ErrorResponse errorResponse(FilterParseException exception) {
+    return new ErrorResponse(Status.BAD_REQUEST, exception.getMessage())
+      .setScimType(ErrorMessageType.INVALID_FILTER);
   }
-
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/GenericExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/GenericExceptionMapper.java
@@ -20,25 +20,18 @@
 package org.apache.directory.scim.server.exception;
 
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.directory.scim.protocol.Constants;
 import org.apache.directory.scim.protocol.data.ErrorResponse;
 
 @Provider
 @Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
-public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
+public class GenericExceptionMapper extends BaseScimExceptionMapper<Throwable> {
 
   @Override
-  public Response toResponse(Throwable throwable) {
-    ErrorResponse em = new ErrorResponse(Response.Status.INTERNAL_SERVER_ERROR, throwable.getMessage());
-
-    Response response = em.toResponse();
-    response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
-
-    return response;
+  protected ErrorResponse errorResponse(Throwable throwable) {
+    return new ErrorResponse(Response.Status.INTERNAL_SERVER_ERROR, throwable.getMessage());
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/ResourceExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/ResourceExceptionMapper.java
@@ -20,11 +20,8 @@
 package org.apache.directory.scim.server.exception;
 
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.directory.scim.protocol.Constants;
 import org.apache.directory.scim.protocol.ErrorMessageType;
@@ -33,10 +30,10 @@ import org.apache.directory.scim.spec.exception.ResourceException;
 
 @Provider
 @Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
-public class ResourceExceptionMapper implements ExceptionMapper<ResourceException> {
+public class ResourceExceptionMapper extends BaseScimExceptionMapper<ResourceException> {
 
   @Override
-  public Response toResponse(ResourceException e) {
+  protected ErrorResponse errorResponse(ResourceException e) {
     Status status = Status.fromStatusCode(e.getStatus());
     ErrorResponse errorResponse = new ErrorResponse(status, e.getMessage());
 
@@ -53,9 +50,6 @@ public class ResourceExceptionMapper implements ExceptionMapper<ResourceExceptio
       errorResponse.setDetail(e.getMessage());
     }
 
-    Response response = errorResponse.toResponse();
-    response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
-
-    return response;
+    return errorResponse;
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/ScimExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/ScimExceptionMapper.java
@@ -20,10 +20,7 @@
 package org.apache.directory.scim.server.exception;
 
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.directory.scim.protocol.Constants;
 import org.apache.directory.scim.protocol.data.ErrorResponse;
@@ -31,13 +28,10 @@ import org.apache.directory.scim.protocol.exception.ScimException;
 
 @Provider
 @Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
-public class ScimExceptionMapper implements ExceptionMapper<ScimException> {
+public class ScimExceptionMapper extends BaseScimExceptionMapper<ScimException> {
 
   @Override
-  public Response toResponse(ScimException e) {
-    Response response = e.getError().toResponse();
-    response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
-
-    return response;
+  protected ErrorResponse errorResponse(ScimException e) {
+    return e.getError();
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnsupportedFilterExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnsupportedFilterExceptionMapper.java
@@ -26,12 +26,11 @@ import org.apache.directory.scim.protocol.ErrorMessageType;
 import org.apache.directory.scim.protocol.data.ErrorResponse;
 import org.apache.directory.scim.spec.exception.UnsupportedFilterException;
 
-public class UnsupportedFilterExceptionMapper implements ExceptionMapper<UnsupportedFilterException> {
+public class UnsupportedFilterExceptionMapper extends BaseScimExceptionMapper<UnsupportedFilterException> {
 
   @Override
-  public Response toResponse(UnsupportedFilterException exception) {
-    ErrorResponse error = new ErrorResponse(Response.Status.BAD_REQUEST, ErrorMessageType.INVALID_FILTER.getDetail())
+  protected ErrorResponse errorResponse(UnsupportedFilterException throwable) {
+    return new ErrorResponse(Response.Status.BAD_REQUEST, ErrorMessageType.INVALID_FILTER.getDetail())
       .setScimType(ErrorMessageType.INVALID_FILTER);
-    return error.toResponse();
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnsupportedOperationExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnsupportedOperationExceptionMapper.java
@@ -20,25 +20,18 @@
 package org.apache.directory.scim.server.exception;
 
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.apache.directory.scim.protocol.Constants;
 import org.apache.directory.scim.protocol.data.ErrorResponse;
 
 @Provider
 @Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
-public class UnsupportedOperationExceptionMapper implements ExceptionMapper<UnsupportedOperationException> {
+public class UnsupportedOperationExceptionMapper extends BaseScimExceptionMapper<UnsupportedOperationException> {
 
   @Override
-  public Response toResponse(UnsupportedOperationException throwable) {
-    ErrorResponse em = new ErrorResponse(Response.Status.NOT_IMPLEMENTED, throwable.getMessage());
-
-    Response response = em.toResponse();
-    response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
-
-    return response;
+  protected ErrorResponse errorResponse(UnsupportedOperationException throwable) {
+    return new ErrorResponse(Response.Status.NOT_IMPLEMENTED, throwable.getMessage());
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/WebApplicationExceptionMapper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/WebApplicationExceptionMapper.java
@@ -21,11 +21,8 @@ package org.apache.directory.scim.server.exception;
 
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
 import org.apache.directory.scim.protocol.Constants;
@@ -33,15 +30,10 @@ import org.apache.directory.scim.protocol.data.ErrorResponse;
 
 @Provider
 @Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
-public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
+public class WebApplicationExceptionMapper extends BaseScimExceptionMapper<WebApplicationException> {
 
   @Override
-  public Response toResponse(WebApplicationException e) {
-    ErrorResponse em = new ErrorResponse(Status.fromStatusCode(e.getResponse().getStatus()), e.getMessage());
-
-    Response response = em.toResponse();
-    response.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, Constants.SCIM_CONTENT_TYPE);
-
-    return response;
+  protected ErrorResponse errorResponse(WebApplicationException e) {
+    return new ErrorResponse(Status.fromStatusCode(e.getResponse().getStatus()), e.getMessage());
   }
 }


### PR DESCRIPTION
Adds logging to make sure exceptions are not lost, this level may need to be tweaked, the container or other JAX-RS extensions could be handling this type of logging
