### PR TITLE
Add jandex index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -554,6 +554,19 @@
             <artifactId>spring-boot-maven-plugin</artifactId>
             <version>${version.spring-boot}</version>
           </plugin>
+          <plugin>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex-maven-plugin</artifactId>
+            <version>3.0.4</version>
+            <executions>
+              <execution>
+                <id>make-index</id>
+                <goals>
+                  <goal>jandex</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -140,4 +140,13 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -69,4 +69,12 @@
       <scope>test</scope>
     </dependency>
 </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Allows for Quarkus/Smallrye to find JAX-RS components across jars
