### PR TITLE
Configure and run the ITs on the Jersey example

### DIFF
--- a/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/junit/EmbeddedServerExtension.java
+++ b/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/junit/EmbeddedServerExtension.java
@@ -86,7 +86,7 @@ public class EmbeddedServerExtension implements BeforeAllCallback, BeforeEachCal
   }
 
   public interface ScimTestServer {
-    URI start(int port);
-    void shutdown();
+    URI start(int port) throws Exception;
+    void shutdown() throws Exception;
   }
 }

--- a/scim-server-examples/scim-server-jersey/pom.xml
+++ b/scim-server-examples/scim-server-jersey/pom.xml
@@ -35,22 +35,27 @@
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-grizzly2-http</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext.cdi</groupId>
       <artifactId>jersey-weld2-se</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -75,6 +80,12 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.directory.scim</groupId>
+      <artifactId>scim-compliance-tests</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/scim-server-examples/scim-server-jersey/src/main/resources/beans.xml
+++ b/scim-server-examples/scim-server-jersey/src/main/resources/beans.xml
@@ -17,6 +17,6 @@
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.1" bean-discovery-mode="all">
+       version="4.0" bean-discovery-mode="annotated">
        
 </beans>

--- a/scim-server-examples/scim-server-jersey/src/test/resources/META-INF/services/org.apache.directory.scim.compliance.junit.EmbeddedServerExtension$ScimTestServer
+++ b/scim-server-examples/scim-server-jersey/src/test/resources/META-INF/services/org.apache.directory.scim.compliance.junit.EmbeddedServerExtension$ScimTestServer
@@ -1,0 +1,1 @@
+org.apache.directory.scim.example.jersey.JerseyTestServer


### PR DESCRIPTION
Update example runner to use standard Jakarta bootstraping instead of implementation specific code
