### PR TITLE
Require "resourceType" in ScimResource constructor

### DIFF
--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/RepositoryRegistryTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/RepositoryRegistryTest.java
@@ -68,12 +68,7 @@ public class RepositoryRegistryTest {
     final static String NAME = "Stub";
 
     public StubResource() {
-      super(URN);
-    }
-
-    @Override
-    public String getResourceType() {
-      return NAME;
+      super(URN, NAME);
     }
   }
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
@@ -63,11 +63,6 @@ public class ScimGroup extends ScimResource implements Serializable {
   }
 
   public ScimGroup() {
-    super(SCHEMA_URI);
-  }
-
-  @Override
-  public String getResourceType() {
-    return RESOURCE_NAME;
+    super(SCHEMA_URI, RESOURCE_NAME);
   }
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -73,11 +73,14 @@ public abstract class ScimResource extends BaseResource implements Serializable 
   // (XmlElementAny?)
   private Map<String, ScimExtension> extensions = new HashMap<String, ScimExtension>();
 
-  private String baseUrn;
+  private final String baseUrn;
 
-  public ScimResource(String urn) {
+  private final String resourceType;
+
+  public ScimResource(String urn, String resourceType) {
     super(urn);
     this.baseUrn = urn;
+    this.resourceType = resourceType;
 
     ScimResourceType resourceTypeAnnotation = getClass().getAnnotation(ScimResourceType.class);
     if (resourceTypeAnnotation != null) {
@@ -129,8 +132,6 @@ public abstract class ScimResource extends BaseResource implements Serializable 
 
     return se[0];
   }
-
-  public abstract String getResourceType();
 
   public String getBaseUrn() {
     return baseUrn;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResourceWithOptionalId.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResourceWithOptionalId.java
@@ -42,8 +42,8 @@ public abstract class ScimResourceWithOptionalId extends ScimResource {
   @XmlElement
   String id;
   
-  public ScimResourceWithOptionalId(String urn) {
-    super(urn);
+  public ScimResourceWithOptionalId(String urn, String resourceType) {
+    super(urn, resourceType);
   }
   
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
@@ -135,12 +135,7 @@ public class ScimUser extends ScimResource implements Serializable {
   List<X509Certificate> x509Certificates;
 
   public ScimUser() {
-    super(SCHEMA_URI);
-  }
-
-  @Override
-  public String getResourceType() {
-    return RESOURCE_NAME;
+    super(SCHEMA_URI, RESOURCE_NAME);
   }
 
   public Optional<Address> getPrimaryAddress() {

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
@@ -79,21 +79,14 @@ public class ResourceType extends ScimResourceWithOptionalId {
   List<SchemaExtentionConfiguration> schemaExtensions;
   
   public ResourceType() {
-    super(SCHEMA_URI);
+    super(SCHEMA_URI, RESOURCE_NAME);
   }
   
   public ResourceType(ScimResourceType annotation) {
-    super(SCHEMA_URI);
+    super(SCHEMA_URI, RESOURCE_NAME);
     this.name = annotation.name();
     this.description = annotation.description();
     this.schemaUrn = annotation.schema();
     this.endpoint = annotation.endpoint();
   }
-
-  @Override
-  public String getResourceType() {
-    return RESOURCE_NAME;
-  }
-  
-  
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
@@ -175,12 +175,7 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
   List<AuthenticationSchema> authenticationSchemes;
 
   public ServiceProviderConfiguration() {
-    super(SCHEMA_URI);
-  }
-
-  @Override
-  public String getResourceType() {
-    return RESOURCE_NAME;
+    super(SCHEMA_URI, RESOURCE_NAME);
   }
 
 }


### PR DESCRIPTION
Remove the need to implement a method downstream as this value doesn't change.
