### PR TITLE
Move the common SCIMple CDI & JSON bits from scim-server to scim-core

### DIFF
--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -36,17 +36,30 @@
     </dependency>
     <dependency>
       <groupId>org.apache.directory.scim</groupId>
+      <artifactId>scim-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.directory.scim</groupId>
       <artifactId>scim-spec-protocol</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <scope>test</scope>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -58,6 +71,38 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>4.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.connectors</groupId>
+      <artifactId>jersey-jdk-connector</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.ext.cdi</groupId>
+      <artifactId>jersey-weld2-se</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   
 </project>

--- a/scim-client/src/main/java/org/apache/directory/scim/client/rest/BaseScimClient.java
+++ b/scim-client/src/main/java/org/apache/directory/scim/client/rest/BaseScimClient.java
@@ -66,7 +66,7 @@ public abstract class BaseScimClient<T extends ScimResource> implements AutoClos
     if (endpoint == null) {
       throw new IllegalArgumentException("scimResourceClass: " + scimResourceClass.getSimpleName() + " must have annotation " + ScimResourceType.class.getSimpleName() + " and annotation must have non-null endpoint");
     }
-    this.client = client;
+    this.client = client.register(ScimJacksonXmlBindJsonProvider.class);
     this.scimResourceClass = scimResourceClass;
     this.scimResourceListResponseGenericType = scimResourceListGenericType;
     this.target = this.client.target(baseUrl).path(endpoint);

--- a/scim-client/src/main/java/org/apache/directory/scim/client/rest/ResourceTypesClient.java
+++ b/scim-client/src/main/java/org/apache/directory/scim/client/rest/ResourceTypesClient.java
@@ -40,7 +40,7 @@ public class ResourceTypesClient implements AutoCloseable {
   private final ResourceTypesResourceClient resourceTypesResourceClient = new ResourceTypesResourceClient();
 
   public ResourceTypesClient(Client client, String baseUrl) {
-    this.client = client;
+    this.client = client.register(ScimJacksonXmlBindJsonProvider.class);
     this.target = this.client.target(baseUrl).path("ResourceTypes");
   }
 

--- a/scim-client/src/main/java/org/apache/directory/scim/client/rest/ScimJacksonXmlBindJsonProvider.java
+++ b/scim-client/src/main/java/org/apache/directory/scim/client/rest/ScimJacksonXmlBindJsonProvider.java
@@ -17,18 +17,17 @@
 * under the License.
 */
 
-package org.apache.directory.scim.server.rest;
+package org.apache.directory.scim.client.rest;
 
 import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.apache.directory.scim.core.json.ObjectMapperFactory;
-import org.apache.directory.scim.core.schema.SchemaRegistry;
-import org.apache.directory.scim.protocol.Constants;
-
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.ext.Provider;
+import org.apache.directory.scim.core.json.ObjectMapperFactory;
+import org.apache.directory.scim.core.schema.SchemaRegistry;
+import org.apache.directory.scim.protocol.Constants;
 
 /**
  * Adds JacksonJaxbJsonProvider for custom MediaType {@code application/scim+json}.

--- a/scim-client/src/main/java/org/apache/directory/scim/client/rest/ScimSelfClient.java
+++ b/scim-client/src/main/java/org/apache/directory/scim/client/rest/ScimSelfClient.java
@@ -42,7 +42,7 @@ public class ScimSelfClient implements AutoCloseable {
   private RestCall invoke = Invocation::invoke;
 
   public ScimSelfClient(Client client, String baseUrl) {
-    this.client = client;
+    this.client = client.register(ScimJacksonXmlBindJsonProvider.class);
     this.target = this.client.target(baseUrl).path(SelfResource.PATH);
     this.selfResourceClient = new SelfResourceClient();
   }

--- a/scim-client/src/test/java/org/apache/directory/scim/client/rest/ClientTestSupport.java
+++ b/scim-client/src/test/java/org/apache/directory/scim/client/rest/ClientTestSupport.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.client.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import okhttp3.mockwebserver.MockResponse;
+import org.apache.directory.scim.client.rest.junit.MockServerClientTestRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+@ExtendWith(MockServerClientTestRunner.class)
+abstract class ClientTestSupport {
+
+  private final ObjectWriter objectWriter = new ObjectMapper().writerWithDefaultPrettyPrinter();
+
+  MockResponse scimResponse() {
+    return new MockResponse()
+      .setHeader("Content-Type", "application/scim+json");
+  }
+
+  MockResponse scimResponse(Map json) {
+    try {
+      return scimResponse()
+        .setBody(objectWriter.writeValueAsString(json))
+        .setResponseCode(200);
+    } catch (JsonProcessingException e) {
+      Assertions.fail(e);
+      return null;
+    }
+  }
+}

--- a/scim-client/src/test/java/org/apache/directory/scim/client/rest/ScimUserClientTest.java
+++ b/scim-client/src/test/java/org/apache/directory/scim/client/rest/ScimUserClientTest.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.client.rest;
+
+import jakarta.ws.rs.core.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.directory.scim.protocol.data.ListResponse;
+import org.apache.directory.scim.protocol.data.PatchRequest;
+import org.apache.directory.scim.protocol.data.SearchRequest;
+import org.apache.directory.scim.protocol.exception.ScimException;
+import org.apache.directory.scim.spec.filter.FilterBuilder;
+import org.apache.directory.scim.spec.patch.PatchOperation;
+import org.apache.directory.scim.spec.patch.PatchOperationPath;
+import org.apache.directory.scim.spec.resources.ScimUser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ScimUserClientTest extends ClientTestSupport {
+
+  @Test
+  public void notFound(MockWebServer server, ScimUserClient client) throws Exception {
+
+    server.enqueue(scimResponse()
+      .setResponseCode(404));
+
+    assertThat(client.getById("invalid-id")).isNotPresent();
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getPath()).isEqualTo("/v2/Users/invalid-id");
+  }
+
+  @Test
+  public void basic200(MockWebServer server, ScimUserClient client) throws Exception {
+
+    server.enqueue(scimResponse()
+      .setBody("{\"id\": \"valid-id\"}")
+      .setResponseCode(200));
+
+    assertThat(client.getById("valid-id")).isPresent().get().hasFieldOrPropertyWithValue("id", "valid-id");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getPath()).isEqualTo("/v2/Users/valid-id");
+
+  }
+
+  @Test
+  public void client500(MockWebServer server, ScimUserClient client) throws Exception {
+
+    server.enqueue(new MockResponse()
+      .setResponseCode(500));
+
+    assertThrows(ScimException.class, () -> client.getById("id"));
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getPath()).isEqualTo("/v2/Users/id");
+  }
+
+  @Test
+  public void queryAll(MockWebServer server, ScimUserClient client) throws Exception {
+    server.enqueue(scimResponse(Map.of(
+      "schemas", List.of("urn:ietf:params:scim:api:messages:2.0:ListResponse"),
+      "totalResults", 2,
+      "Resources", List.of(
+        Map.of("id", "2819c223-7f76-453a-919d-413861904646",
+          "userName", "bjensen"),
+        Map.of("id", "c75ad752-64ae-4823-840d-ffa80929976c",
+          "userName", "jsmith")
+      )
+    )));
+
+    ScimUser bjensen = new ScimUser();
+    bjensen.setUserName("bjensen");
+    bjensen.setId("2819c223-7f76-453a-919d-413861904646");
+
+    ScimUser jsmith = new ScimUser();
+    jsmith.setUserName("jsmith");
+    jsmith.setId("c75ad752-64ae-4823-840d-ffa80929976c");
+
+    ListResponse<ScimUser> users = client.query(null, null, null, null, null, null, null);
+    assertThat(users.getItemsPerPage()).isNull();
+    assertThat(users.getStartIndex()).isNull();
+    assertThat(users.getTotalResults()).isEqualTo(2);
+    assertThat(users.getResources()).containsExactly(bjensen, jsmith);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getPath()).isEqualTo("/v2/Users");
+  }
+
+  @Test
+  public void create(MockWebServer server, ScimUserClient client) throws Exception {
+    server.enqueue(scimResponse(Map.of(
+      "id", "created-id", "userName", "testUser")));
+
+    ScimUser testUser = new ScimUser();
+    testUser.setUserName("testUser");
+
+    ScimUser expectedUser = new ScimUser();
+    expectedUser.setUserName("testUser");
+    expectedUser.setId("created-id");
+
+    assertThat(client.create(testUser)).isEqualTo(expectedUser);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("POST");
+    assertThat(request.getPath()).isEqualTo("/v2/Users");
+  }
+
+  @Test
+  public void findByFilter(MockWebServer server, ScimUserClient client) throws Exception {
+    server.enqueue(scimResponse(Map.of(
+      "schemas", List.of("urn:ietf:params:scim:api:messages:2.0:ListResponse"),
+      "totalResults", 1,
+      "Resources", List.of(
+        Map.of("id", "2819c223-7f76-453a-919d-413861904646",
+          "userName", "bjensen")
+      )
+    )));
+
+    ScimUser bjensen = new ScimUser();
+    bjensen.setUserName("bjensen");
+    bjensen.setId("2819c223-7f76-453a-919d-413861904646");
+
+    SearchRequest searchRequest = new SearchRequest()
+      .setFilter(FilterBuilder.create().equalTo("userName", "bjensen").build());
+
+    ListResponse<ScimUser> users = client.find(searchRequest);
+    assertThat(users.getItemsPerPage()).isNull();
+    assertThat(users.getStartIndex()).isNull();
+    assertThat(users.getTotalResults()).isEqualTo(1);
+    assertThat(users.getResources()).containsExactly(bjensen);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("POST");
+    assertThat(request.getPath()).isEqualTo("/v2/Users/.search");
+  }
+
+  @Test
+  public void update(MockWebServer server, ScimUserClient client) throws Exception {
+
+    server.enqueue(scimResponse(Map.of(
+      "id", "updated-id", "userName", "testUser")));
+
+    ScimUser testUser = new ScimUser();
+    testUser.setUserName("testUser");
+    testUser.setId("updated-id");
+
+    ScimUser expectedUser = new ScimUser();
+    expectedUser.setUserName("testUser");
+    expectedUser.setId("updated-id");
+
+    ScimUser resultUser = client.update("updated-id", testUser);
+    assertThat(resultUser).isEqualTo(expectedUser);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("PUT");
+    assertThat(request.getPath()).isEqualTo("/v2/Users/updated-id");
+  }
+
+  @Test
+  public void update500(MockWebServer server, ScimUserClient client) throws Exception {
+
+    server.enqueue(new MockResponse()
+      .setResponseCode(500));
+
+    ScimUser testUser = new ScimUser();
+    testUser.setUserName("testUser");
+    testUser.setId("500-id");
+
+    ScimException exception = assertThrows(ScimException.class, () -> client.update("500-id", testUser));
+    assertThat(exception.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  public void patch(MockWebServer server, ScimUserClient client) throws Exception {
+
+    server.enqueue(scimResponse(Map.of(
+      "id", "patched-id", "userName", "testUser")));
+
+    PatchRequest patchRequest = new PatchRequest().add(
+      new PatchOperation()
+        .setOperation(PatchOperation.Type.REMOVE)
+        .setPath(new PatchOperationPath("name.honorificPrefix"))
+    );
+
+    ScimUser expectedUser = new ScimUser();
+    expectedUser.setUserName("testUser");
+    expectedUser.setId("patched-id");
+
+    ScimUser resultUser = client.patch("patched-id", patchRequest);
+    assertThat(resultUser).isEqualTo(expectedUser);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("PATCH");
+    assertThat(request.getPath()).isEqualTo("/v2/Users/patched-id");
+  }
+
+  @Test
+  public void delete(MockWebServer server, ScimUserClient client) throws Exception {
+    server.enqueue(new MockResponse()
+      .setResponseCode(204));
+
+    client.delete("delete-id");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("DELETE");
+    assertThat(request.getPath()).isEqualTo("/v2/Users/delete-id");
+  }
+
+  @Test
+  public void delete500(MockWebServer server, ScimUserClient client) throws Exception {
+
+    server.enqueue(new MockResponse()
+      .setResponseCode(500));
+
+    ScimException exception = assertThrows(ScimException.class, () -> client.delete("500-id"));
+    assertThat(exception.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/scim-client/src/test/java/org/apache/directory/scim/client/rest/junit/MockServerClientTestRunner.java
+++ b/scim-client/src/test/java/org/apache/directory/scim/client/rest/junit/MockServerClientTestRunner.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.client.rest.junit;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.directory.scim.client.rest.ScimUserClient;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.jdk.connector.JdkConnectorProvider;
+import org.jboss.weld.environment.se.Weld;
+import org.junit.jupiter.api.extension.*;
+
+import java.util.List;
+
+public class MockServerClientTestRunner implements ParameterResolver, BeforeEachCallback, AfterEachCallback, BeforeTestExecutionCallback {
+
+  private final List<Class<?>> supportedClasses = List.of(MockWebServer.class, ScimUserClient.class, Client.class);
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    return supportedClasses.contains(parameterContext.getParameter().getType());
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context) throws ParameterResolutionException {
+
+    Class<?> paramType = parameterContext.getParameter().getType();
+    if (ScimUserClient.class.equals(paramType)) {
+
+      MockWebServer server = fromStore(MockWebServer.class, context);
+      Client client = fromStore(Client.class, context);
+
+      ScimUserClient scimUserClient = new ScimUserClient(client, server.url("/v2").toString());
+      getStore(context).put(ScimUserClient.class, scimUserClient);
+      return scimUserClient;
+    }
+
+    return fromStore(paramType, context);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+
+    Weld weld = new Weld();
+    getStore(context).put(Weld.class, weld);
+
+    MockWebServer server = new MockWebServer();
+    getStore(context).put(MockWebServer.class, server);
+
+    Client client = ClientBuilder.newBuilder()
+      .withConfig( // the default Jersey client does not support PATCH requests
+        new ClientConfig().connectorProvider(new JdkConnectorProvider()))
+      .build();
+    getStore(context).put(Client.class, client);
+  }
+
+  @Override
+  public void beforeTestExecution(ExtensionContext context) throws Exception {
+
+    MockWebServer server = fromStore(MockWebServer.class, context);
+    if (server != null) {
+      server.start();
+    }
+
+    Weld weld = fromStore(Weld.class, context);
+    if (weld != null) {
+      weld.initialize();
+    }
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    MockWebServer server = fromStore(MockWebServer.class, context);
+    if (server != null) {
+      server.shutdown();
+    }
+
+    Weld weld = fromStore(Weld.class, context);
+    if (weld != null) {
+      weld.shutdown();
+    }
+
+    Client client = fromStore(Client.class, context);
+    if (client != null) {
+      client.close();
+    }
+
+    ScimUserClient userClient = fromStore(ScimUserClient.class, context);
+    if (userClient != null) {
+      userClient.close();
+    }
+  }
+
+  private ExtensionContext.Store getStore(ExtensionContext context) {
+    return context.getStore(ExtensionContext.Namespace.create(this));
+  }
+
+  private <T> T fromStore(Class<T> type, ExtensionContext context) {
+    return getStore(context).get(type, type);
+  }
+}

--- a/scim-core/pom.xml
+++ b/scim-core/pom.xml
@@ -45,6 +45,14 @@
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.flipkart.zjsonpatch</groupId>
       <artifactId>zjsonpatch</artifactId>
       <version>0.4.13</version>

--- a/scim-core/src/main/java/org/apache/directory/scim/core/json/ObjectMapperFactory.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/json/ObjectMapperFactory.java
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-package org.apache.directory.scim.server.rest;
+package org.apache.directory.scim.core.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
@@ -38,7 +38,7 @@ import java.io.IOException;
 /**
  * Creates and configures an {@link ObjectMapper} used for {@code application/scim+json} parsing.
  */
-class ObjectMapperFactory {
+public class ObjectMapperFactory {
 
   private final static ObjectMapper objectMapper = createObjectMapper();
 
@@ -48,7 +48,7 @@ class ObjectMapperFactory {
    * serializing REST response and requests.
    * @return an ObjectMapper configured for use with Jackson and Jakarta bindings.
    */
-  static ObjectMapper getObjectMapper() {
+  public static ObjectMapper getObjectMapper() {
     return objectMapper;
   }
 
@@ -69,7 +69,7 @@ class ObjectMapperFactory {
   /**
    * Creates and configures an {@link ObjectMapper} SCIM Resource in REST request and responses {@code application/scim+json}.
    */
-  static ObjectMapper createObjectMapper(SchemaRegistry schemaRegistry) {
+  public static ObjectMapper createObjectMapper(SchemaRegistry schemaRegistry) {
     ObjectMapper objectMapper = createObjectMapper().copy();
     objectMapper.registerModule(new JakartaXmlBindAnnotationModule());
     objectMapper.registerModule(new ScimResourceModule(schemaRegistry));

--- a/scim-core/src/main/java/org/apache/directory/scim/core/json/ScimResourceDeserializer.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/json/ScimResourceDeserializer.java
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-package org.apache.directory.scim.server.rest;
+package org.apache.directory.scim.core.json;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/scim-core/src/main/java/org/apache/directory/scim/core/spi/Eager.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/spi/Eager.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.directory.scim.server.spi;
+package org.apache.directory.scim.core.spi;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/scim-core/src/main/java/org/apache/directory/scim/core/spi/ScimpleComponents.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/spi/ScimpleComponents.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.directory.scim.server.spi;
+package org.apache.directory.scim.core.spi;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
@@ -26,6 +26,7 @@ import jakarta.enterprise.inject.Produces;
 import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.repository.RepositoryRegistry;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
+import org.apache.directory.scim.core.spi.Eager;
 import org.apache.directory.scim.spec.resources.ScimResource;
 
 import java.util.stream.Collectors;

--- a/scim-core/src/main/java/org/apache/directory/scim/core/spi/ScimpleInitializer.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/spi/ScimpleInitializer.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.core.spi;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessBean;
+import jakarta.enterprise.inject.spi.ProcessProducerField;
+import jakarta.enterprise.inject.spi.ProcessProducerMethod;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ScimpleInitializer implements Extension {
+
+  private final Set<Bean<?>> eagerBeans = new HashSet<>();
+
+  public <T> void collect(@Observes ProcessBean<T> event) {
+    if (event.getAnnotated().isAnnotationPresent(Eager.class)) {
+      eagerBeans.add(event.getBean());
+    }
+  }
+
+  public <T, X> void collect(@Observes ProcessProducerMethod<T, X> event) {
+    if (event.getAnnotated().isAnnotationPresent(Eager.class)) {
+      eagerBeans.add(event.getBean());
+    }
+  }
+
+  public <T, X> void collect(@Observes ProcessProducerField<T, X> event) {
+    if (event.getAnnotated().isAnnotationPresent(Eager.class)) {
+      eagerBeans.add(event.getBean());
+    }
+  }
+
+  public void load(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
+    eagerBeans.forEach(bean -> {
+      // call a real method so the proxied bean gets created
+      beanManager.getReference(bean, Object.class, beanManager.createCreationalContext(bean)).toString();
+    });
+  }
+}

--- a/scim-core/src/main/resources/META-INF/beans.xml
+++ b/scim-core/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="annotated">
+</beans>

--- a/scim-core/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/scim-core/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.apache.directory.scim.core.spi.ScimpleInitializer

--- a/scim-core/src/test/java/org/apache/directory/scim/core/json/ObjectMapperFactoryTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/json/ObjectMapperFactoryTest.java
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-package org.apache.directory.scim.server.rest;
+package org.apache.directory.scim.core.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
-import org.apache.directory.scim.server.utility.ExampleObjectExtension;
+import org.apache.directory.scim.core.utility.ExampleObjectExtension;
 import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.assertj.core.api.Assertions;

--- a/scim-core/src/test/java/org/apache/directory/scim/core/utility/ExampleObjectExtension.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/utility/ExampleObjectExtension.java
@@ -1,0 +1,99 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ 
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.core.utility;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
+import org.apache.directory.scim.spec.annotation.ScimExtensionType;
+import org.apache.directory.scim.spec.resources.ScimExtension;
+import org.apache.directory.scim.spec.schema.Schema.Attribute.Mutability;
+import org.apache.directory.scim.spec.schema.Schema.Attribute.Returned;
+
+import java.io.Serializable;
+import java.util.List;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
+@ScimExtensionType(required = false, name = "ExampleObject", id = ExampleObjectExtension.URN, description = "Example Object Extensions.")
+@Data
+public class ExampleObjectExtension implements ScimExtension {
+
+  private static final long serialVersionUID = -5398090056271556423L;
+
+  public static final String URN = "urn:ietf:params:scim:schemas:extension:example:2.0:Object";
+
+  @XmlType
+  @XmlAccessorType(XmlAccessType.NONE)
+  @Data
+  public static class ComplexObject implements Serializable {
+
+    private static final long serialVersionUID = 2822581434679824690L;
+
+    @ScimAttribute(description = "The \"id\" of the complex object.")
+    @XmlElement
+    private String value;
+
+    @ScimAttribute(mutability = Mutability.READ_ONLY, description = "displayName of the object.")
+    @XmlElement
+    private String displayName;
+  }
+
+  @ScimAttribute(returned = Returned.ALWAYS)
+  @XmlElement
+  private String valueAlways;
+
+  @ScimAttribute(returned = Returned.DEFAULT)
+  @XmlElement
+  private String valueDefault;
+
+  @ScimAttribute(returned = Returned.NEVER)
+  @XmlElement
+  private String valueNever;
+
+  @ScimAttribute(returned = Returned.REQUEST)
+  @XmlElement
+  private String valueRequest;
+  
+  @ScimAttribute(returned = Returned.REQUEST)
+  @XmlElement
+  private ComplexObject valueComplex;
+  
+  @ScimAttribute
+  @XmlElement
+  private List<String> list;
+  
+  @ScimAttribute
+  @XmlElement
+  private List<Order> enumList;
+  
+  @ScimAttribute
+  @XmlElement
+  private Subobject subobject;
+
+  @Override
+  public String getUrn() {
+    return URN;
+  }
+}

--- a/scim-core/src/test/java/org/apache/directory/scim/core/utility/Order.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/utility/Order.java
@@ -1,0 +1,44 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ 
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.core.utility;
+
+public enum Order {
+  
+  FIRST("first"),
+  SECOND("second"),
+  THIRD("third"),
+  FOURTH("fourth");
+  
+  Order(String value) {
+    this.value = value;
+  }
+  
+  private final String value;
+  
+  public String getValue() {
+    return value;
+  }
+  
+  @Override
+  public String toString() {
+    return value;
+  }
+
+}

--- a/scim-core/src/test/java/org/apache/directory/scim/core/utility/Subobject.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/utility/Subobject.java
@@ -1,0 +1,57 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ 
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.core.utility;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+public class Subobject implements Serializable {
+  
+  private static final long serialVersionUID = -8081556701833520316L;
+
+  @ScimAttribute
+  @XmlElement
+  private String string1;
+  
+  @ScimAttribute
+  @XmlElement
+  private String string2;
+  
+  @ScimAttribute
+  @XmlElement
+  private Boolean boolean1;
+  
+  @ScimAttribute
+  @XmlElement
+  private Boolean boolean2;
+  
+  @ScimAttribute
+  @XmlElement
+  private List<String> list1;
+
+  @ScimAttribute
+  @XmlElement
+  private List<String> list2;
+}

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/EtagGenerator.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/EtagGenerator.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.server.rest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.directory.scim.core.json.ObjectMapperFactory;
 import org.apache.directory.scim.server.exception.EtagGenerationException;
 import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.schema.Meta;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/spi/ScimServerInitializer.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/spi/ScimServerInitializer.java
@@ -27,32 +27,10 @@ import org.apache.directory.scim.server.configuration.ServerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
 
 public class ScimServerInitializer implements Extension {
 
   private final Logger log = LoggerFactory.getLogger(ScimServerInitializer.class);
-
-  private final Set<Bean<?>> eagerBeans = new HashSet<>();
-
-  public <T> void collect(@Observes ProcessBean<T> event) {
-    if (event.getAnnotated().isAnnotationPresent(Eager.class)) {
-      eagerBeans.add(event.getBean());
-    }
-  }
-
-  public <T, X> void collect(@Observes ProcessProducerMethod<T, X> event) {
-    if (event.getAnnotated().isAnnotationPresent(Eager.class)) {
-      eagerBeans.add(event.getBean());
-    }
-  }
-
-  public <T, X> void collect(@Observes ProcessProducerField<T, X> event) {
-    if (event.getAnnotated().isAnnotationPresent(Eager.class)) {
-      eagerBeans.add(event.getBean());
-    }
-  }
 
   public void defaultBeans(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
     if (beanManager.getBeans(ServerConfiguration.class).isEmpty()) {
@@ -67,12 +45,5 @@ public class ScimServerInitializer implements Extension {
           return beanManager.createBean(ba, ServerConfiguration.class, beanManager.getInjectionTargetFactory(at)).create(cc);
         });
     }
-  }
-
-  public void load(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
-    eagerBeans.forEach(bean -> {
-      // call a real method so the proxied bean gets created
-      beanManager.getReference(bean, Object.class, beanManager.createCreationalContext(bean)).toString();
-    });
   }
 }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
@@ -19,11 +19,10 @@
 
 package org.apache.directory.scim.server.rest;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.directory.scim.core.json.ObjectMapperFactory;
 import org.apache.directory.scim.server.utility.ExampleObjectExtension;
 import org.apache.directory.scim.server.utility.ExampleObjectExtension.ComplexObject;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension;

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/PatchRequest.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/PatchRequest.java
@@ -19,6 +19,8 @@
 
 package org.apache.directory.scim.protocol.data;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import jakarta.xml.bind.annotation.XmlAccessType;
@@ -44,4 +46,12 @@ public class PatchRequest extends BaseResource {
   
   @XmlElement(name = "Operations")
   List<PatchOperation> patchOperationList;
+
+  public PatchRequest add(PatchOperation operation) {
+    if (patchOperationList == null){
+      patchOperationList = new ArrayList<>();
+    }
+    patchOperationList.add(operation);
+    return this;
+  }
 }


### PR DESCRIPTION
This way scim-client does not depend on scim-server for the loading of the object mapper and SchemaRegistry

Added basic scim-client tests (which uncovered this problem)

Future note: these CDI and JSON bits _could_ be moved to new modules if we need to support other JSON modules or other injection frameworks
As is, the CDI providers would be brought in to the spring-boot module, but would not be used.
