### PR TITLE
Fix flaky tests in PhoneNumberBuilderTest

### DIFF
--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/resources/PhoneNumberBuilderTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/resources/PhoneNumberBuilderTest.java
@@ -709,7 +709,9 @@ public class PhoneNumberBuilderTest {
 
     assertEquals("+1-888-888-5555", phoneNumber.getNumber());
     assertEquals("1234", phoneNumber.getExtension());
-    assertEquals(("tel:+1-888-888-5555;ext=1234;milhouse=simpson;example=gh234"), phoneNumber.getValue());
+    assertTrue(phoneNumber.getValue().contains("tel:+1-888-888-5555;ext=1234;"));
+    assertTrue(phoneNumber.getValue().contains("milhouse=simpson"));
+    assertTrue(phoneNumber.getValue().contains("example=gh234"));
   }
   
   @Test
@@ -725,7 +727,9 @@ public class PhoneNumberBuilderTest {
     assertEquals("888-5555", phoneNumber.getNumber());
     assertEquals("+1-888", phoneNumber.getPhoneContext());
     assertEquals("example.a.com", phoneNumber.getSubAddress());
-    assertEquals(("tel:888-5555;isub=example.a.com;phone-context=+1-888;milhouse=simpson;example=gh234"), phoneNumber.getValue());
+    assertTrue(phoneNumber.getValue().contains("tel:888-5555;isub=example.a.com;phone-context=+1-888;"));
+    assertTrue(phoneNumber.getValue().contains("milhouse=simpson"));
+    assertTrue(phoneNumber.getValue().contains("example=gh234"));
   }
   
   @Test


### PR DESCRIPTION
### Motivation

PhoneNumberBuilderTest has the following tests that are flaky, detected using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool:
org.apache.directory.scim.spec.resources.PhoneNumberBuilderTest#test_adding_params_for_GlobalPhoneNumberBuilder
org.apache.directory.scim.spec.resources.PhoneNumberBuilderTest#test_adding_params_for_LocalPhoneNumberBuilder

The tests fail due to non-deterministic ordering in the HashMap `params` of the `PhoneNumber` class.

### Command to reproduce
`mvn -pl scim-spec/scim-spec-schema edu.illinois:nondex-maven-plugin:2.1.1:nondex -Denforcer.skip=true -Dtest=org.apache.directory.scim.spec.resources.PhoneNumberBuilderTest`

### Assertions that fail
```
assertEquals(("tel:+1-888-888-5555;ext=1234;milhouse=simpson;example=gh234"), phoneNumber.getValue());
assertEquals(("tel:888-5555;isub=example.a.com;phone-context=+1-888;milhouse=simpson;example=gh234"), phoneNumber.getValue());
```
### Log
```
[ERROR] Failures: 
[ERROR]   PhoneNumberBuilderTest.test_adding_params_for_GlobalPhoneNumberBuilder:712 expected: <tel:+1-888-888-5555;ext=1234;milhouse=simpson;example=gh234> but was: <tel:+1-888-888-5555;ext=1234;example=gh234;milhouse=simpson>
[ERROR]   PhoneNumberBuilderTest.test_adding_params_for_LocalPhoneNumberBuilder:728 expected: <tel:888-5555;[isub=example.a.com](http://isub%3Dexample.a.com/);phone-context=+1-888;milhouse=simpson;example=gh234> but was: <tel:888-5555;[isub=example.a.com](http://isub%3Dexample.a.com/);phone-context=+1-888;example=gh234;milhouse=simpson>
```

### Changes
The non-deterministic part of `phoneNumber.getValue()` is the params, so assert that `phoneNumber.getValue()`contains the params in such a way that the order of the params is not assumed.

Another way to fix the tests is to change the datatype of `param` from HashMap to LinkedHashMap in the `PhoneNumber` class as LinkedHashMap maintains the order of its elements - but this would require changing the main code.