### PR TITLE
Make PhoneNumber.param entry order consistent

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/PhoneNumber.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/PhoneNumber.java
@@ -23,7 +23,7 @@
 package org.apache.directory.scim.spec.resources;
 
 import java.io.Serializable;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -122,7 +122,7 @@ public class PhoneNumber extends KeyedResource implements Serializable, TypedAtt
 
   public void addParam(String name, String value) {
     if (this.params == null) {
-      this.params = new HashMap<String, String>();
+      this.params = new LinkedHashMap<>();
     }
 
     this.params.put(name, value);
@@ -270,8 +270,8 @@ public class PhoneNumber extends KeyedResource implements Serializable, TypedAtt
     return result;
   }
 
-  HashMap<String, String> paramsToLowerCase() {
-    HashMap<String, String> paramsLowercase = new HashMap<String, String>();
+  Map<String, String> paramsToLowerCase() {
+    Map<String, String> paramsLowercase = new LinkedHashMap<>();
     for (Entry<String, String> entry : params.entrySet()) {
       paramsLowercase.put(entry.getKey().toLowerCase(), entry.getValue().toLowerCase());
     }
@@ -288,7 +288,7 @@ public class PhoneNumber extends KeyedResource implements Serializable, TypedAtt
       return false;
     }
 
-    HashMap<String, String> paramsLowercase = paramsToLowerCase();
+    Map<String, String> paramsLowercase = paramsToLowerCase();
 
     for (Entry<String, String> entry : otherParams.entrySet()) {
       String foundValue = paramsLowercase.get(entry.getKey().toLowerCase());
@@ -323,7 +323,7 @@ public class PhoneNumber extends KeyedResource implements Serializable, TypedAtt
     String extension;
     String subAddress;
     String phoneContext;
-    Map<String, String> params;
+    LinkedHashMap<String, String> params;
 
     boolean isGlobalNumber = false;
     boolean isDomainPhoneContext = false;
@@ -348,9 +348,14 @@ public class PhoneNumber extends KeyedResource implements Serializable, TypedAtt
       return this;
     }
 
+    public PhoneNumberBuilder setParams(Map<String, String> params) {
+      this.params = params != null ? new LinkedHashMap<>(params) : null;
+      return this;
+    }
+
     public PhoneNumberBuilder param(String name, String value) {
       if (this.params == null) {
-        this.params = new HashMap<String, String>();
+        this.params = new LinkedHashMap<>();
       }
 
       this.params.put(name, value);

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/resources/PhoneNumberBuilderTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/resources/PhoneNumberBuilderTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.directory.scim.spec.resources;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -709,7 +709,7 @@ public class PhoneNumberBuilderTest {
 
     assertEquals("+1-888-888-5555", phoneNumber.getNumber());
     assertEquals("1234", phoneNumber.getExtension());
-    assertEquals(("tel:+1-888-888-5555;ext=1234;milhouse=simpson;example=gh234"), phoneNumber.getValue());
+    assertEquals(("tel:+1-888-888-5555;ext=1234;example=gh234;milhouse=simpson"), phoneNumber.getValue());
   }
   
   @Test
@@ -725,7 +725,7 @@ public class PhoneNumberBuilderTest {
     assertEquals("888-5555", phoneNumber.getNumber());
     assertEquals("+1-888", phoneNumber.getPhoneContext());
     assertEquals("example.a.com", phoneNumber.getSubAddress());
-    assertEquals(("tel:888-5555;isub=example.a.com;phone-context=+1-888;milhouse=simpson;example=gh234"), phoneNumber.getValue());
+    assertEquals(("tel:888-5555;isub=example.a.com;phone-context=+1-888;example=gh234;milhouse=simpson"), phoneNumber.getValue());
   }
   
   @Test
@@ -937,7 +937,7 @@ public class PhoneNumberBuilderTest {
                      .param("NOPQR", "STUVWXYZ.-_")
                      .build();
     
-    HashMap<String, String> lowerP = ph.paramsToLowerCase();
+    Map<String, String> lowerP = ph.paramsToLowerCase();
     
     assertEquals(2, lowerP.size());
     assertEquals("fghijklm", lowerP.get("abcde"));


### PR DESCRIPTION
This should possibly be sorted map instead of an ordered one, but starting with predictable output is still an improvement.

Fixes: #200
