### PR TITLE
SCIM Resources will now have predictable ordered sets and maps

### DIFF
--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -46,8 +46,6 @@ import org.apache.directory.scim.spec.exception.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import org.apache.directory.scim.core.repository.UpdateRequest;
 import org.apache.directory.scim.core.repository.annotations.ScimProcessingExtension;
 import org.apache.directory.scim.core.repository.extensions.AttributeFilterExtension;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.spec.resources;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import jakarta.validation.constraints.Size;
 import jakarta.xml.bind.annotation.XmlAccessType;
@@ -48,17 +49,24 @@ public abstract class BaseResource implements Serializable {
   @Size(min = 1)
   @Urn
   Set<String> schemas;
-  
-  public BaseResource(String urn) {
+
+  public BaseResource(@Urn String urn) {
     addSchema(urn);
   }
-  
-  public void addSchema(String urn) {
+
+  public void addSchema(@Urn String urn) {
     if (schemas == null){
-      schemas = new HashSet<>();
+      schemas = new TreeSet<>();
     }
-    
     schemas.add(urn);
+  }
+
+  public void setSchemas(@Urn Set<String> schemas) {
+    if (schemas == null) {
+      this.schemas.clear();
+    } else {
+      this.schemas = new TreeSet<>(schemas);
+    }
   }
   
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -38,6 +38,7 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -71,7 +72,7 @@ public abstract class ScimResource extends BaseResource implements Serializable 
 
   // TODO - Figure out JAXB equivalent of JsonAnyGetter and JsonAnySetter
   // (XmlElementAny?)
-  private Map<String, ScimExtension> extensions = new HashMap<String, ScimExtension>();
+  private Map<String, ScimExtension> extensions = new LinkedHashMap<>();
 
   private final String baseUrn;
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
@@ -288,6 +288,7 @@ public final class Schemas {
       attributeList.add(attribute);
     }
 
+    attributeList.sort(Comparator.comparing(o -> o.name));
     log.debug("Returning " + attributeList.size() + " attributes");
     return attributeList;
   }


### PR DESCRIPTION
- Remove unused import
- SCIM Resources will now have predictable ordered sets and maps
