### PR TITLE
Fixed Wildfly related issues

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/RepositoryRegistry.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/RepositoryRegistry.java
@@ -38,6 +38,10 @@ public class RepositoryRegistry {
 
   private Map<Class<? extends ScimResource>, Repository<? extends ScimResource>> repositoryMap = new HashMap<>();
 
+  public RepositoryRegistry() {
+    // CDI
+  }
+
   public RepositoryRegistry(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
   }

--- a/scim-server-examples/scim-server-memory/README.md
+++ b/scim-server-examples/scim-server-memory/README.md
@@ -8,7 +8,7 @@ This example WAR project demo's how to:
 
 Use this as a starter point on how to integrate Apache Directory SCIMple into your own project.
 
-Run: `mvn tomee:run` and then access one of the endpoints:
+Run: `mvn` and then access one of the endpoints:
 
 ```bash
 # httpie

--- a/scim-server-examples/scim-server-memory/pom.xml
+++ b/scim-server-examples/scim-server-memory/pom.xml
@@ -57,7 +57,7 @@
   </dependencies>
 
   <build>
-    <defaultGoal>package tomee:run</defaultGoal>
+    <defaultGoal>package wildfly:run</defaultGoal>
     <plugins>
       <plugin>
         <groupId>org.apache.geronimo.genesis.plugins</groupId>
@@ -67,20 +67,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.tomee.maven</groupId>
-        <artifactId>tomee-maven-plugin</artifactId>
-        <version>9.0.0-M8</version>
-        <configuration>
-          <context>ROOT</context>
-          <warFile>target/${project.artifactId}-${project.version}.war</warFile>
-          <tomeeClassifier>plus</tomeeClassifier>
-          <simpleLog>true</simpleLog>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
-        <version>4.0.0.Alpha2</version>
+        <version>4.0.0.Final</version>
         <configuration>
           <skip>false</skip>
           <filename>${project.artifactId}-${project.version}.war</filename>

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/rest/RestApplication.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/rest/RestApplication.java
@@ -22,29 +22,18 @@ package org.apache.directory.scim.example.memory.rest;
 import jakarta.enterprise.inject.Produces;
 import org.apache.directory.scim.server.configuration.ServerConfiguration;
 
-import java.util.Set;
-
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
-import org.apache.directory.scim.server.rest.ScimpleFeature;
 
 import static org.apache.directory.scim.spec.schema.ServiceProviderConfiguration.AuthenticationSchema.httpBasic;
 
 @ApplicationPath("v2")
 public class RestApplication extends Application {
-  
-  @Override
-  public Set<Class<?>> getClasses() {
-    return Set.of(ScimpleFeature.class);
-  }
 
   @Produces
   ServerConfiguration serverConfiguration() {
     return new ServerConfiguration()
       .setId("scimple-in-memory-example")
       .addAuthenticationSchema(httpBasic());
-
-    // set the auth scheme too
-    // .addAuthenticationSchema(oauthBearer());
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/BulkResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/BulkResourceImpl.java
@@ -99,7 +99,8 @@ public class BulkResourceImpl implements BulkResource {
     this.repositoryRegistry = repositoryRegistry;
   }
 
-  BulkResourceImpl() {
+  public BulkResourceImpl() {
+    // CDI
     this(null, null);
   }
 

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/GroupResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/GroupResourceImpl.java
@@ -39,7 +39,8 @@ public class GroupResourceImpl extends BaseResourceTypeResourceImpl<ScimGroup> i
     super(schemaRegistry, repositoryRegistry, requestContext, etagGenerator, ScimGroup.class);
   }
 
-  GroupResourceImpl() {
+  public GroupResourceImpl() {
+    // CDI
     this(null, null, null, null);
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/ResourceTypesResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/ResourceTypesResourceImpl.java
@@ -47,7 +47,8 @@ public class ResourceTypesResourceImpl implements ResourceTypesResource {
     this.requestContext = requestContext;
   }
 
-  ResourceTypesResourceImpl() {
+  public ResourceTypesResourceImpl() {
+    // CDI
     this(null, null);
   }
 

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/SchemaResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/SchemaResourceImpl.java
@@ -45,7 +45,8 @@ public class SchemaResourceImpl implements SchemaResource {
     this.schemaRegistry = schemaRegistry;
   }
 
-  SchemaResourceImpl() {
+  public SchemaResourceImpl() {
+    // CDI
     this(null);
   }
 

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonXmlBindJsonProvider.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimJacksonXmlBindJsonProvider.java
@@ -39,9 +39,12 @@ import jakarta.ws.rs.ext.Provider;
 @ApplicationScoped
 public class ScimJacksonXmlBindJsonProvider extends JacksonXmlBindJsonProvider {
 
+  public ScimJacksonXmlBindJsonProvider() {
+    // CDI
+  }
+
   @Inject
   public ScimJacksonXmlBindJsonProvider(SchemaRegistry schemaRegistry) {
     super(ObjectMapperFactory.createObjectMapper(schemaRegistry), DEFAULT_ANNOTATIONS);
-
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/SelfResourceImpl.java
@@ -56,7 +56,8 @@ public class SelfResourceImpl implements SelfResource {
     this.requestContext = requestContext;
   }
 
-  SelfResourceImpl() {
+  public SelfResourceImpl() {
+    // CDI
     this(null, null, null);
   }
 

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/ServiceProviderConfigResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/ServiceProviderConfigResourceImpl.java
@@ -53,7 +53,8 @@ public class ServiceProviderConfigResourceImpl implements ServiceProviderConfigR
     this.etagGenerator = etagGenerator;
   }
 
-  ServiceProviderConfigResourceImpl() {
+  public ServiceProviderConfigResourceImpl() {
+    // CDI
     this(null, null);
   }
 

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/UserResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/UserResourceImpl.java
@@ -43,7 +43,8 @@ public class UserResourceImpl extends BaseResourceTypeResourceImpl<ScimUser> imp
     super(schemaRegistry, repositoryRegistry, requestContext, etagGenerator, ScimUser.class);
   }
 
-  UserResourceImpl() {
+  public UserResourceImpl() {
+    // CDI
     this(null, null, null, null);
   }
 }


### PR DESCRIPTION
Testing with Wildfly uncovered a few issues:
* Resource classes must have a public default constructor (CDI related requirements)
* Resources cannot be added via a Feature
* Removed up tomee refs in example until v10 is released
