### PR TITLE
Add enforcer rule to ensure dependencies have compatible bytecode versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <jdk.version>11</jdk.version>
+    <max.jdk.version>${jdk.version}</max.jdk.version>
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
     <maven.compiler.target>${jdk.version}</maven.compiler.target>
     <maven.compiler.release>${jdk.version}</maven.compiler.release>
@@ -379,6 +380,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.1.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.6.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>enforce-java</id>
@@ -391,6 +399,20 @@
                   <version>17</version>
                 </requireJavaVersion>
               </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>${max.jdk.version}</maxJdkVersion>
+                </enforceBytecodeVersion>
+              </rules>
+              <fail>true</fail>
             </configuration>
           </execution>
         </executions>

--- a/scim-coverage/pom.xml
+++ b/scim-coverage/pom.xml
@@ -28,6 +28,11 @@
   <name>SCIM - Total Test Coverage</name>
   <packaging>pom</packaging>
 
+  <properties>
+    <!-- The spring modules require 17 -->
+    <max.jdk.version>17</max.jdk.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.directory.scim</groupId>
@@ -76,17 +81,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>spring-boot</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.directory.scim</groupId>
-          <artifactId>scim-spring-boot-starter</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
 </project>

--- a/scim-server-examples/scim-server-spring-boot/pom.xml
+++ b/scim-server-examples/scim-server-spring-boot/pom.xml
@@ -29,6 +29,7 @@
 
   <properties>
     <module.name>org.apache.directory.scim.example.springboot</module.name>
+    <max.jdk.version>17</max.jdk.version>
   </properties>
 
   <dependencyManagement>

--- a/support/spring-boot/pom.xml
+++ b/support/spring-boot/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <module.name>org.apache.directory.scim.spring</module.name>
+    <max.jdk.version>17</max.jdk.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
All non-spring modules require Java 11 (Spring modules Java 17)