### PR TITLE
Remove resources classes from Feature implementation

### DIFF
--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/JerseyApplication.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/JerseyApplication.java
@@ -31,7 +31,7 @@ import java.net.URI;
 import java.util.Set;
 
 import jakarta.ws.rs.core.Application;
-import org.apache.directory.scim.server.rest.ScimpleFeature;
+import org.apache.directory.scim.server.rest.ScimResourceHelper;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
@@ -47,7 +47,7 @@ public class JerseyApplication extends Application {
   
   @Override
   public Set<Class<?>> getClasses() {
-    return Set.of(ScimpleFeature.class);
+    return ScimResourceHelper.scimpleFeatureAndResourceClasses();
   }
 
   @Produces

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimResourceHelper.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimResourceHelper.java
@@ -19,7 +19,12 @@
 
 package org.apache.directory.scim.server.rest;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.directory.scim.server.exception.*;
 
@@ -32,6 +37,36 @@ import org.apache.directory.scim.server.exception.*;
  */
 public final class ScimResourceHelper {
 
+  static final Set<Class<?>> RESOURCE_CLASSES = Set.of(
+    BulkResourceImpl.class,
+    GroupResourceImpl.class,
+    ResourceTypesResourceImpl.class,
+    SchemaResourceImpl.class,
+    SearchResourceImpl.class,
+    SelfResourceImpl.class,
+    ServiceProviderConfigResourceImpl.class,
+    UserResourceImpl.class);
+
+  static final Set<Class<?>> EXCEPTION_MAPPER_CLASSES = Set.of(
+    UnsupportedFilterExceptionMapper.class,
+    ResourceExceptionMapper.class,
+    ScimExceptionMapper.class,
+    FilterParseExceptionMapper.class,
+    WebApplicationExceptionMapper.class,
+    UnsupportedOperationExceptionMapper.class,
+    GenericExceptionMapper.class);
+
+  static final Set<Class<?>> MEDIA_TYPE_SUPPORT_CLASSES = Set.of(
+    ScimJacksonXmlBindJsonProvider.class
+  );
+
+  static final Set<Class<?>> SCIMPLE_CLASSES = Stream.of(
+      RESOURCE_CLASSES,
+      EXCEPTION_MAPPER_CLASSES,
+      MEDIA_TYPE_SUPPORT_CLASSES)
+      .flatMap(Collection::stream)
+      .collect(Collectors.toUnmodifiableSet());
+
   private ScimResourceHelper() {
     // Make this a utility class
   }
@@ -41,30 +76,16 @@ public final class ScimResourceHelper {
    * functionality.
    * 
    * @return the JAX-RS annotated classes.
+   * @deprecated use {@link ScimResourceHelper#scimpleFeatureAndResourceClasses}
    */
+  @Deprecated
   public static Set<Class<?>> getScimClassesToLoad() {
+    return SCIMPLE_CLASSES;
+  }
 
-    // Required scim classes.
-    return Set.of(
-      BulkResourceImpl.class,
-      GroupResourceImpl.class,
-      ResourceTypesResourceImpl.class,
-      SchemaResourceImpl.class,
-      SearchResourceImpl.class,
-      SelfResourceImpl.class,
-      ServiceProviderConfigResourceImpl.class,
-      UserResourceImpl.class,
-
-      // exception mappers
-      UnsupportedFilterExceptionMapper.class,
-      ResourceExceptionMapper.class,
-      ScimExceptionMapper.class,
-      FilterParseExceptionMapper.class,
-      WebApplicationExceptionMapper.class,
-      UnsupportedOperationExceptionMapper.class,
-      GenericExceptionMapper.class,
-
-    // handle MediaType of application/scim+json
-    ScimJacksonXmlBindJsonProvider.class);
+  public static Set<Class<?>> scimpleFeatureAndResourceClasses() {
+    Set<Class<?>> classes = new HashSet<>(RESOURCE_CLASSES);
+    classes.add(ScimpleFeature.class);
+    return Collections.unmodifiableSet(classes);
   }
 }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimpleFeature.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/ScimpleFeature.java
@@ -23,12 +23,19 @@ import jakarta.ws.rs.core.Feature;
 import jakarta.ws.rs.core.FeatureContext;
 import jakarta.ws.rs.ext.Provider;
 
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static org.apache.directory.scim.server.rest.ScimResourceHelper.*;
+
 @Provider
 public class ScimpleFeature implements Feature {
 
   @Override
   public boolean configure(FeatureContext context) {
-    ScimResourceHelper.getScimClassesToLoad().forEach(context::register);
+    Stream.of(EXCEPTION_MAPPER_CLASSES, MEDIA_TYPE_SUPPORT_CLASSES)
+      .flatMap(Collection::stream)
+      .forEach(context::register);
     return true;
   }
 }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/App.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/App.java
@@ -23,7 +23,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.core.Application;
 import org.apache.directory.scim.server.configuration.ServerConfiguration;
-import org.apache.directory.scim.server.rest.ScimpleFeature;
+import org.apache.directory.scim.server.rest.ScimResourceHelper;
 
 import java.util.Set;
 
@@ -34,7 +34,7 @@ public class App extends Application {
 
   @Override
   public Set<Class<?>> getClasses() {
-    return Set.of(ScimpleFeature.class);
+    return ScimResourceHelper.scimpleFeatureAndResourceClasses();
   }
 
   @Produces

--- a/support/spring-boot/src/main/java/org/apache/directory/scim/spring/ScimpleSpringConfiguration.java
+++ b/support/spring-boot/src/main/java/org/apache/directory/scim/spring/ScimpleSpringConfiguration.java
@@ -31,7 +31,7 @@ import org.apache.directory.scim.protocol.UserResource;
 import org.apache.directory.scim.server.configuration.ServerConfiguration;
 import org.apache.directory.scim.server.rest.EtagGenerator;
 import org.apache.directory.scim.server.rest.RequestContext;
-import org.apache.directory.scim.server.rest.ScimpleFeature;
+import org.apache.directory.scim.server.rest.ScimResourceHelper;
 import org.apache.directory.scim.server.rest.UserResourceImpl;
 import org.apache.directory.scim.spec.resources.ScimResource;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -114,7 +114,7 @@ public class ScimpleSpringConfiguration {
   static class ScimpleJaxRsApplication extends Application {
     @Override
     public Set<Class<?>> getClasses() {
-      return Set.of(ScimpleFeature.class);
+      return ScimResourceHelper.scimpleFeatureAndResourceClasses();
     }
   }
 


### PR DESCRIPTION
Registering endpoints in a Feature is a gray area with JAX-RS. This seems to work with Jetty but not Wildfly.
Based on community feedback this doesn't seem to be a valid expectation of a Feature.

This change limits ScimpleFeature to only registering ExceptionMappers and Media Type related classes
And adds util functionality in ScimResourceHelper
