### PR TITLE
Fix typo in SchemaExtensionConfiguration

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/schema/SchemaRegistry.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/schema/SchemaRegistry.java
@@ -174,7 +174,7 @@ public class SchemaRegistry {
 
     if (extensionList != null) {
 
-      List<ResourceType.SchemaExtentionConfiguration> extensionSchemaList = new ArrayList<>();
+      List<ResourceType.SchemaExtensionConfiguration> extensionSchemaList = new ArrayList<>();
 
       for (Class<? extends ScimExtension> se : extensionList) {
 
@@ -184,7 +184,7 @@ public class SchemaRegistry {
           throw new InvalidExtensionException("Missing annotation: @ScimExtensionType on ScimExtensionL " + se.getSimpleName());
         }
 
-        ResourceType.SchemaExtentionConfiguration ext = new ResourceType.SchemaExtentionConfiguration();
+        ResourceType.SchemaExtensionConfiguration ext = new ResourceType.SchemaExtensionConfiguration();
         ext.setRequired(extensionType.required());
         ext.setSchemaUrn(extensionType.id());
         extensionSchemaList.add(ext);

--- a/scim-core/src/test/java/org/apache/directory/scim/core/schema/SchemaRegistryTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/schema/SchemaRegistryTest.java
@@ -47,7 +47,7 @@ public class SchemaRegistryTest {
     userType.setSchemaUrn(ScimUser.SCHEMA_URI);
     userType.setName(ScimUser.RESOURCE_NAME);
     userType.setDescription("Top level ScimUser");
-    userType.setSchemaExtensions(List.of(new ResourceType.SchemaExtentionConfiguration().setSchemaUrn(ExampleObjectExtension.URN)));
+    userType.setSchemaExtensions(List.of(new ResourceType.SchemaExtensionConfiguration().setSchemaUrn(ExampleObjectExtension.URN)));
 
     ResourceType groupType = new ResourceType();
     groupType.setId(ScimGroup.RESOURCE_NAME);

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
@@ -48,7 +48,7 @@ public class ResourceType extends ScimResourceWithOptionalId {
   public static final String SCHEMA_URI = "urn:ietf:params:scim:schemas:core:2.0:ResourceType";
 
   @Data
-  public static class SchemaExtentionConfiguration {
+  public static class SchemaExtensionConfiguration {
 
     @XmlElement(name = "schema")
     @Urn
@@ -76,7 +76,7 @@ public class ResourceType extends ScimResourceWithOptionalId {
   String schemaUrn;
 
   @XmlElement
-  List<SchemaExtentionConfiguration> schemaExtensions;
+  List<SchemaExtensionConfiguration> schemaExtensions;
   
   public ResourceType() {
     super(SCHEMA_URI, RESOURCE_NAME);


### PR DESCRIPTION
Fixes a ~~non~~-breaking typo with `SchemaExtensionConfiguration`, e.g. Extention -> Extension