### PR TITLE
Use UUIDs for examples

### DIFF
--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.jersey.service;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.server.exception.UnableToUpdateResourceException;
 import org.apache.directory.scim.core.repository.Repository;
@@ -38,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -62,7 +64,8 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
   @PostConstruct
   public void init() {
     ScimGroup group = new ScimGroup();
-    group.setId("example-group");
+    group.setId(UUID.randomUUID().toString());
+    group.setDisplayName("example-group");
     groups.put(group.getId(), group);
   }
 
@@ -73,18 +76,16 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
 
   @Override
   public ScimGroup create(ScimGroup resource) throws UnableToCreateResourceException {
-    String resourceId = resource.getId();
-    int idCandidate = resource.hashCode();
-    String id = resourceId != null ? resourceId : Integer.toString(idCandidate);
+    String id = UUID.randomUUID().toString();
 
-    while (groups.containsKey(id)) {
-      id = Integer.toString(idCandidate);
-      ++idCandidate;
+    // if the external ID is not set, use the displayName instead
+    if (!StringUtils.isEmpty(resource.getExternalId())) {
+      resource.setExternalId(resource.getDisplayName());
     }
 
     // check to make sure the group doesn't already exist
     boolean existingUserFound = groups.values().stream()
-      .anyMatch(group -> group.getExternalId().equals(resource.getExternalId()));
+      .anyMatch(group -> resource.getExternalId().equals(group.getExternalId()));
     if (existingUserFound) {
       // HTTP leaking into data layer
       throw new UnableToCreateResourceException(Response.Status.CONFLICT, "Group '" + resource.getExternalId() + "' already exists.");

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.jersey.service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
@@ -53,7 +54,7 @@ import org.apache.directory.scim.core.schema.SchemaRegistry;
 @ApplicationScoped
 public class InMemoryUserService implements Repository<ScimUser> {
 
-  static final String DEFAULT_USER_ID = "1";
+  static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
   static final String DEFAULT_USER_DISPLAY_NAME = "User " + DEFAULT_USER_ID;
   static final String DEFAULT_USER_EMAIL_VALUE = "e1@example.com";
@@ -106,14 +107,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
    */
   @Override
   public ScimUser create(ScimUser resource) throws UnableToCreateResourceException {
-    String resourceId = resource.getId();
-    int idCandidate = resource.hashCode();
-    String id = resourceId != null ? resourceId : Integer.toString(idCandidate);
-
-    while (users.containsKey(id)) {
-      id = Integer.toString(idCandidate);
-      ++idCandidate;
-    }
+    String id = UUID.randomUUID().toString();
 
     // check to make sure the user doesn't already exist
     boolean existingUserFound = users.values().stream()

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.memory.service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
@@ -53,7 +54,7 @@ import org.apache.directory.scim.core.schema.SchemaRegistry;
 @ApplicationScoped
 public class InMemoryUserService implements Repository<ScimUser> {
 
-  static final String DEFAULT_USER_ID = "1";
+  static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
   static final String DEFAULT_USER_DISPLAY_NAME = "User " + DEFAULT_USER_ID;
   static final String DEFAULT_USER_EMAIL_VALUE = "e1@example.com";
@@ -106,14 +107,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
    */
   @Override
   public ScimUser create(ScimUser resource) throws UnableToCreateResourceException {
-    String resourceId = resource.getId();
-    int idCandidate = resource.hashCode();
-    String id = resourceId != null ? resourceId : Integer.toString(idCandidate);
-
-    while (users.containsKey(id)) {
-      id = Integer.toString(idCandidate);
-      ++idCandidate;
-    }
+    String id = UUID.randomUUID().toString();
 
     // check to make sure the user doesn't already exist
     boolean existingUserFound = users.values().stream()

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/ScimpleSpringBootApplication.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/ScimpleSpringBootApplication.java
@@ -20,10 +20,11 @@
 package org.apache.directory.scim.example.spring;
 
 import org.apache.directory.scim.server.configuration.ServerConfiguration;
-import org.apache.directory.scim.spec.schema.ServiceProviderConfiguration.AuthenticationSchema;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+
+import static org.apache.directory.scim.spec.schema.ServiceProviderConfiguration.AuthenticationSchema.httpBasic;
 
 @SpringBootApplication
 public class ScimpleSpringBootApplication {
@@ -37,9 +38,9 @@ public class ScimpleSpringBootApplication {
     // Set any unique configuration bits
     return new ServerConfiguration()
       .setId("scimple-spring-boot-example")
-      .setDocumentationUri("https://github.com/apache/directory-scimple");
+      .setDocumentationUri("https://github.com/apache/directory-scimple")
 
-    // set the auth scheme too
-    // .addAuthenticationSchema(oauthBearer());
+     // set the auth scheme
+     .addAuthenticationSchema(httpBasic());
   }
 }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -34,9 +34,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 public class InMemoryGroupService implements Repository<ScimGroup> {
@@ -52,7 +54,8 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
   @PostConstruct
   public void init() {
     ScimGroup group = new ScimGroup();
-    group.setId("example-group");
+    group.setId(UUID.randomUUID().toString());
+    group.setDisplayName("example-group");
     groups.put(group.getId(), group);
   }
 
@@ -63,18 +66,16 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
 
   @Override
   public ScimGroup create(ScimGroup resource) throws UnableToCreateResourceException {
-    String resourceId = resource.getId();
-    int idCandidate = resource.hashCode();
-    String id = resourceId != null ? resourceId : Integer.toString(idCandidate);
+    String id = UUID.randomUUID().toString();
 
-    while (groups.containsKey(id)) {
-      id = Integer.toString(idCandidate);
-      ++idCandidate;
+    // if the external ID is not set, use the displayName instead
+    if (!StringUtils.hasText(resource.getExternalId())) {
+      resource.setExternalId(resource.getDisplayName());
     }
 
     // check to make sure the group doesn't already exist
     boolean existingUserFound = groups.values().stream()
-      .anyMatch(group -> group.getExternalId().equals(resource.getExternalId()));
+      .anyMatch(group -> resource.getExternalId().equals(group.getExternalId()));
     if (existingUserFound) {
       // HTTP leaking into data layer
       throw new UnableToCreateResourceException(Response.Status.CONFLICT, "Group '" + resource.getExternalId() + "' already exists.");

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.spring.service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
@@ -46,7 +47,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class InMemoryUserService implements Repository<ScimUser> {
 
-  static final String DEFAULT_USER_ID = "1";
+  static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
   static final String DEFAULT_USER_DISPLAY_NAME = "User " + DEFAULT_USER_ID;
   static final String DEFAULT_USER_EMAIL_VALUE = "e1@example.com";
@@ -96,14 +97,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
    */
   @Override
   public ScimUser create(ScimUser resource) throws UnableToCreateResourceException {
-    String resourceId = resource.getId();
-    int idCandidate = resource.hashCode();
-    String id = resourceId != null ? resourceId : Integer.toString(idCandidate);
-
-    while (users.containsKey(id)) {
-      id = Integer.toString(idCandidate);
-      ++idCandidate;
-    }
+    String id = UUID.randomUUID().toString();
 
     // check to make sure the user doesn't already exist
     boolean existingUserFound = users.values().stream()


### PR DESCRIPTION
On create, always set the resourceId, it isn't valid for a client to set it
