### PR TITLE
Fix fluent method return types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <version.slf4j>1.7.36</version.slf4j>
     <version.antlr4>4.11.1</version.antlr4>
     <version.resteasy>6.2.2.Final</version.resteasy>
-    <version.spring-boot>3.0.1</version.spring-boot>
+    <version.spring-boot>3.0.2</version.spring-boot>
 
     <!-- default surefire/failsafe arg lines to empty-->
     <jacoco.argline></jacoco.argline>

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -19,9 +19,7 @@
 
 package org.apache.directory.scim.server.rest;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -346,7 +344,7 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
                   .build();
   }
 
-  private T attributesForDisplay(T resource, Set<AttributeReference> includedAttributes, Set<AttributeReference> excludedAttributes) throws AttributeException {
+  private <T extends ScimResource> T attributesForDisplay(T resource, Set<AttributeReference> includedAttributes, Set<AttributeReference> excludedAttributes) throws AttributeException {
     if (!excludedAttributes.isEmpty()) {
       resource = attributeUtil.setExcludedAttributesForDisplay(resource, excludedAttributes);
     } else {

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkRequest.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkRequest.java
@@ -34,7 +34,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @XmlType
 @XmlAccessorType(XmlAccessType.NONE)
-public class BulkRequest extends BaseResource {
+public class BulkRequest extends BaseResource<BulkRequest> {
 
   public static final String SCHEMA_URI = "urn:ietf:params:scim:api:messages:2.0:BulkRequest";
   

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkResponse.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkResponse.java
@@ -36,7 +36,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @XmlType
 @XmlAccessorType(XmlAccessType.NONE)
-public class BulkResponse extends BaseResource {
+public class BulkResponse extends BaseResource<BulkResponse> {
 
   public static final String SCHEMA_URI = "urn:ietf:params:scim:api:messages:2.0:BulkResponse";
 

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ErrorResponse.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ErrorResponse.java
@@ -36,7 +36,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.NONE)
-public class ErrorResponse extends BaseResource {
+public class ErrorResponse extends BaseResource<ErrorResponse> {
 
   private static final long serialVersionUID = 9045421198080348116L;
 

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ListResponse.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ListResponse.java
@@ -34,7 +34,7 @@ import org.apache.directory.scim.spec.resources.BaseResource;
 @EqualsAndHashCode(callSuper = true)
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.NONE)
-public class ListResponse<T> extends BaseResource {
+public class ListResponse<T> extends BaseResource<ListResponse<T>> {
 
   private static final long serialVersionUID = -2381780997440673136L;
 

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/PatchRequest.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/PatchRequest.java
@@ -37,7 +37,7 @@ import org.apache.directory.scim.spec.resources.BaseResource;
 @EqualsAndHashCode(callSuper = true)
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.NONE)
-public class PatchRequest extends BaseResource {
+public class PatchRequest extends BaseResource<PatchRequest> {
   public static final String SCHEMA_URI = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
   
   public PatchRequest() {

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/SearchRequest.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/SearchRequest.java
@@ -49,7 +49,7 @@ import org.apache.directory.scim.spec.resources.BaseResource;
 @EqualsAndHashCode(callSuper = true)
 @XmlType
 @XmlAccessorType(XmlAccessType.NONE)
-public class SearchRequest extends BaseResource {
+public class SearchRequest extends BaseResource<SearchRequest> {
 
   private static final long serialVersionUID = 8217513543318598565L;
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
@@ -20,7 +20,6 @@
 package org.apache.directory.scim.spec.resources;
 
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -41,7 +40,7 @@ import lombok.Data;
  */
 @Data
 @XmlAccessorType(XmlAccessType.NONE)
-public abstract class BaseResource implements Serializable {
+public abstract class BaseResource<SELF extends BaseResource<SELF>> implements Serializable {
 
   private static final long serialVersionUID = -7603956873008734403L;
 
@@ -54,19 +53,25 @@ public abstract class BaseResource implements Serializable {
     addSchema(urn);
   }
 
-  public void addSchema(@Urn String urn) {
+  public SELF addSchema(@Urn String urn) {
     if (schemas == null){
       schemas = new TreeSet<>();
     }
     schemas.add(urn);
+    return self();
   }
 
-  public void setSchemas(@Urn Set<String> schemas) {
+  public SELF setSchemas(@Urn Set<String> schemas) {
     if (schemas == null) {
       this.schemas.clear();
     } else {
       this.schemas = new TreeSet<>(schemas);
     }
+    return self();
   }
-  
+
+  @SuppressWarnings("unchecked")
+  protected SELF self() {
+    return (SELF) this;
+  }
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
@@ -22,7 +22,11 @@ package org.apache.directory.scim.spec.resources;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -30,6 +34,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.annotation.ScimResourceType;
+import org.apache.directory.scim.spec.schema.Meta;
 import org.apache.directory.scim.spec.schema.ResourceReference;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -64,5 +69,40 @@ public class ScimGroup extends ScimResource implements Serializable {
 
   public ScimGroup() {
     super(SCHEMA_URI, RESOURCE_NAME);
+  }
+
+  @Override
+  public ScimGroup setSchemas(Set<String> schemas) {
+    return (ScimGroup) super.setSchemas(schemas);
+  }
+
+  @Override
+  public ScimGroup setMeta(@NotNull Meta meta) {
+    return (ScimGroup) super.setMeta(meta);
+  }
+
+  @Override
+  public ScimGroup setId(@Size(min = 1) String id) {
+    return (ScimGroup) super.setId(id);
+  }
+
+  @Override
+  public ScimGroup setExternalId(String externalId) {
+    return (ScimGroup) super.setExternalId(externalId);
+  }
+
+  @Override
+  public ScimGroup setExtensions(Map<String, ScimExtension> extensions) {
+    return (ScimGroup) super.setExtensions(extensions);
+  }
+
+  @Override
+  public ScimGroup addSchema(String urn) {
+    return (ScimGroup) super.addSchema(urn);
+  }
+
+  @Override
+  public ScimGroup addExtension(ScimExtension extension) {
+    return (ScimGroup) super.addExtension(extension);
   }
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -37,7 +37,6 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -50,7 +49,7 @@ import java.util.Map;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @XmlAccessorType(XmlAccessType.NONE)
-public abstract class ScimResource extends BaseResource implements Serializable {
+public abstract class ScimResource extends BaseResource<ScimResource> implements Serializable {
 
   private static final long serialVersionUID = 3673404125396687366L;
 
@@ -94,7 +93,7 @@ public abstract class ScimResource extends BaseResource implements Serializable 
    * @param extension the scim extension
    * @throws InvalidExtensionException if the ScimExtension passed in is improperly configured.  
    */
-  public void addExtension(ScimExtension extension) {
+  public ScimResource addExtension(ScimExtension extension) {
     ScimExtensionType[] se = extension.getClass().getAnnotationsByType(ScimExtensionType.class);
 
     if (se.length != 1) {
@@ -105,6 +104,7 @@ public abstract class ScimResource extends BaseResource implements Serializable 
     extensions.put(extensionUrn, extension);
     
     addSchema(extensionUrn);
+    return this;
   }
 
   public ScimExtension getExtension(String urn) {

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
@@ -21,8 +21,12 @@ package org.apache.directory.scim.spec.resources;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -30,6 +34,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.annotation.ScimResourceType;
+import org.apache.directory.scim.spec.schema.Meta;
 import org.apache.directory.scim.spec.schema.ResourceReference;
 import org.apache.directory.scim.spec.schema.Schema.Attribute.Returned;
 import org.apache.directory.scim.spec.schema.Schema.Attribute.Uniqueness;
@@ -166,5 +171,40 @@ public class ScimUser extends ScimResource implements Serializable {
     return phoneNumbers.stream()
                        .filter(PhoneNumber::getPrimary)
                        .findFirst();
+  }
+
+  @Override
+  public ScimUser setSchemas(Set<String> schemas) {
+    return (ScimUser) super.setSchemas(schemas);
+  }
+
+  @Override
+  public ScimUser setMeta(@NotNull Meta meta) {
+    return (ScimUser) super.setMeta(meta);
+  }
+
+  @Override
+  public ScimUser setId(@Size(min = 1) String id) {
+    return (ScimUser) super.setId(id);
+  }
+
+  @Override
+  public ScimUser setExternalId(String externalId) {
+    return (ScimUser) super.setExternalId(externalId);
+  }
+
+  @Override
+  public ScimUser setExtensions(Map<String, ScimExtension> extensions) {
+    return (ScimUser) super.setExtensions(extensions);
+  }
+
+  @Override
+  public ScimUser addSchema(String urn) {
+    return (ScimUser) super.addSchema(urn);
+  }
+
+  @Override
+  public ScimUser addExtension(ScimExtension extension) {
+    return (ScimUser) super.addExtension(extension);
   }
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
@@ -20,13 +20,18 @@
 package org.apache.directory.scim.spec.schema;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 
 import org.apache.directory.scim.spec.annotation.ScimResourceType;
+import org.apache.directory.scim.spec.resources.ScimExtension;
+import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimResourceWithOptionalId;
 import org.apache.directory.scim.spec.validator.Urn;
 import lombok.Data;
@@ -88,5 +93,40 @@ public class ResourceType extends ScimResourceWithOptionalId {
     this.description = annotation.description();
     this.schemaUrn = annotation.schema();
     this.endpoint = annotation.endpoint();
+  }
+
+  @Override
+  public ResourceType setSchemas(Set<String> schemas) {
+    return (ResourceType) super.setSchemas(schemas);
+  }
+
+  @Override
+  public ResourceType setMeta(@NotNull Meta meta) {
+    return (ResourceType) super.setMeta(meta);
+  }
+
+  @Override
+  public ResourceType setExternalId(String externalId) {
+    return (ResourceType) super.setExternalId(externalId);
+  }
+
+  @Override
+  public ResourceType setExtensions(Map<String, ScimExtension> extensions) {
+    return (ResourceType) super.setExtensions(extensions);
+  }
+
+  @Override
+  public ResourceType setId(String id) {
+    return (ResourceType) super.setId(id);
+  }
+
+  @Override
+  public ResourceType addSchema(String urn) {
+    return (ResourceType) super.addSchema(urn);
+  }
+
+  @Override
+  public ResourceType addExtension(ScimExtension extension) {
+    return (ResourceType) super.addExtension(extension);
   }
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
@@ -20,7 +20,10 @@
 package org.apache.directory.scim.spec.schema;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -28,6 +31,8 @@ import jakarta.xml.bind.annotation.XmlEnumValue;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 
+import org.apache.directory.scim.spec.resources.ScimExtension;
+import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimResourceWithOptionalId;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -178,4 +183,39 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
     super(SCHEMA_URI, RESOURCE_NAME);
   }
 
+
+  @Override
+  public ServiceProviderConfiguration setSchemas(Set<String> schemas) {
+    return (ServiceProviderConfiguration) super.setSchemas(schemas);
+  }
+
+  @Override
+  public ServiceProviderConfiguration setExtensions(Map<String, ScimExtension> extensions) {
+    return (ServiceProviderConfiguration) super.setExtensions(extensions);
+  }
+
+  @Override
+  public ServiceProviderConfiguration setExternalId(String externalId) {
+    return (ServiceProviderConfiguration) super.setExternalId(externalId);
+  }
+
+  @Override
+  public ServiceProviderConfiguration setMeta(@NotNull Meta meta) {
+    return (ServiceProviderConfiguration) super.setMeta(meta);
+  }
+
+  @Override
+  public ServiceProviderConfiguration setId(String id) {
+    return (ServiceProviderConfiguration) super.setId(id);
+  }
+
+  @Override
+  public ServiceProviderConfiguration addSchema(String urn) {
+    return (ServiceProviderConfiguration) super.addSchema(urn);
+  }
+
+  @Override
+  public ServiceProviderConfiguration addExtension(ScimExtension extension) {
+    return (ServiceProviderConfiguration) super.addExtension(extension);
+  }
 }

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/filter/InMemoryScimFilterMatcherTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/filter/InMemoryScimFilterMatcherTest.java
@@ -50,9 +50,8 @@ public class InMemoryScimFilterMatcherTest {
             .setLocality("Unknown")
             .setPostalCode("012345")
             .setCountry("USA")
-        )); static {
-            USER1.addExtension(new LuckyNumberExtension().setLuckyNumber(111));
-        }
+        ))
+        .addExtension(new LuckyNumberExtension().setLuckyNumber(111));
 
   private final static ScimUser USER2 = user("user2", "User", "Two")
         .setAddresses(List.of(
@@ -64,9 +63,8 @@ public class InMemoryScimFilterMatcherTest {
             .setLocality("CA")
             .setPostalCode("221134")
             .setCountry("USA")
-        )); static {
-            USER2.addExtension(new LuckyNumberExtension().setLuckyNumber(8));
-        }
+        ))
+        .addExtension(new LuckyNumberExtension().setLuckyNumber(8));
 
   @Test
   public void userNameMatch() {


### PR DESCRIPTION
- Bump version.spring-boot from 3.0.1 to 3.0.2
- Fixing return type of fluent setters extending BaseResource
