### PR TITLE
patch fixes and test cases

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/PatchHandlerImpl.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/PatchHandlerImpl.java
@@ -302,6 +302,7 @@ public class PatchHandlerImpl implements PatchHandler {
         AttributeComparisonExpression comparisonExpression = (AttributeComparisonExpression) valuePathExpression.getAttributeExpression();
         checkPrimary(subAttributeName, items, value);
 
+        // Add a new mutable map
         items.add(new HashMap<>(Map.of(
           comparisonExpression.getAttributePath().getSubAttributeName(), comparisonExpression.getCompareValue(),
           subAttributeName, value)));

--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/PatchHandlerImpl.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/PatchHandlerImpl.java
@@ -56,6 +56,8 @@ import static java.util.stream.Collectors.toList;
 @Slf4j
 public class PatchHandlerImpl implements PatchHandler {
 
+  public static final String PRIMARY = "primary";
+
   private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
   private final Map<PatchOperation.Type, PatchOperationHandler> patchOperationHandlers = Map.of(
@@ -173,11 +175,11 @@ public class PatchHandlerImpl implements PatchHandler {
 
   private static void checkPrimary(String subAttributeName, Collection<Map<String, Object>> items, Object value)
   {
-    if (subAttributeName.equals("primary") && value.equals(true)) {
+    if (subAttributeName.equals(PRIMARY) && value.equals(true)) {
       // reset all other values with primary -> false
       items.forEach(item -> {
-        if (item.containsKey("primary")) {
-          item.put("primary", false);
+        if (item.containsKey(PRIMARY)) {
+          item.put(PRIMARY, false);
         }
       });
     }

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -149,7 +149,7 @@ public class PatchHandlerTest {
   }
 
   @Test
-  public void applySingleComplexAttribute() {
+  public void applyAddToMissingSingleComplexAttribute() {
     ScimUser user =  user();
     PatchOperation op = patchOperation(ADD, "addresses[type eq \"work\"].postalCode", "ko4 8qq");
     ScimUser updatedUser = patchHandler.apply(user, List.of(op));

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -128,6 +128,57 @@ public class PatchHandlerTest {
   }
 
   @Test
+  public void applyAddSingleComplexAttribute() {
+    ScimUser user =  user();
+    PatchOperation op = patchOperation(ADD, "name.honorificSuffix", "II");
+    ScimUser updatedUser = patchHandler.apply(user, List.of(op));
+    Name expectedName = new Name()
+      .setFormatted(user.getName().getFormatted())
+      .setHonorificSuffix("II");
+    assertThat(updatedUser.getName()).isEqualTo(expectedName);
+  }
+
+  @Test
+  public void applyReplaceSingleComplexAttribute() {
+    ScimUser user =  user();
+    PatchOperation op = patchOperation(REPLACE, "name.formatted", "Charlie");
+    ScimUser updatedUser = patchHandler.apply(user, List.of(op));
+    Name expectedName = new Name()
+      .setFormatted("Charlie");
+    assertThat(updatedUser.getName()).isEqualTo(expectedName);
+  }
+
+  @Test
+  public void applySingleComplexAttribute() {
+    ScimUser user =  user();
+    PatchOperation op = patchOperation(ADD, "addresses[type eq \"work\"].postalCode", "ko4 8qq");
+    ScimUser updatedUser = patchHandler.apply(user, List.of(op));
+    List<Address> expectedAddresses = List.of(
+      new Address()
+        .setType("work")
+        .setPostalCode("ko4 8qq"));
+    assertThat(updatedUser.getAddresses()).isEqualTo(expectedAddresses);
+  }
+
+  @Test
+  public void settingPrimaryOnMultiValuedShouldResetAllOthersToFalse() {
+    // https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2
+    ScimUser user =  user();
+    PatchOperation op = patchOperation(REPLACE, "emails[type eq \"home\"].primary", true);
+    ScimUser updatedUser = patchHandler.apply(user, List.of(op));
+    List<Email> expectedEmails = List.of(
+      new Email()
+        .setPrimary(false)
+        .setType("work")
+        .setValue("work@example.com"),
+      new Email()
+        .setPrimary(true)
+        .setType("home")
+        .setValue("home@example.com"));
+    assertThat(updatedUser.getEmails()).isEqualTo(expectedEmails);
+  }
+
+  @Test
   public void applyRemoveSubAttribute() {
     PatchOperation op = patchOperation(REMOVE, "name.formatted", null);
     ScimUser updatedUser = patchHandler.apply(user(), List.of(op));


### PR DESCRIPTION
This PR addresses the following PATCH issues/cases:
- Apply PATCH to single complex attribute (e.g. User.name)
- Apply PATCH Add to a MultiValue attribute that is missing (should create the list and then add the object)
- Fixes issue where adding an item to a missing attribute create an unmodifiable map
- address the following RFC requirement ([source](https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2)):

  >   For multi-valued attributes, a PATCH operation that sets a value's "primary" sub-attribute to "true" SHALL cause the server to automatically set "primary" to "false" for any other values in the array.