### PR TITLE
Remove duplicate get user by id test

### DIFF
--- a/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/ScimpleITSupport.java
+++ b/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/ScimpleITSupport.java
@@ -19,6 +19,9 @@
 
 package org.apache.directory.scim.compliance.tests;
 
+import io.restassured.RestAssured;
+import io.restassured.config.Config;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.filter.Filter;
 import io.restassured.filter.FilterContext;
 import io.restassured.filter.log.LogDetail;
@@ -50,6 +53,9 @@ public class ScimpleITSupport {
   private URI uri = URI.create("http://localhost:8080/v2");
 
   private final boolean loggingEnabled = Boolean.getBoolean("scim.tests.logging.enabled");
+
+  private final RestAssuredConfig config = RestAssured.config()
+    .logConfig(RestAssured.config().getLogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
 
   private final Map<String, String> requestHeaders = Map.of(
     "User-Agent", "Apache SCIMple Compliance Tests",
@@ -86,6 +92,7 @@ public class ScimpleITSupport {
   protected ValidatableResponse get(String path, Map<String, String> query) {
     ValidatableResponse responseSpec =
       given()
+        .config(config)
         .urlEncodingEnabled(false) // URL encoding is handled but the URI
         .redirects().follow(false)
         .accept(SCIM_MEDIA_TYPE)
@@ -93,19 +100,20 @@ public class ScimpleITSupport {
       .when()
         .filter(logging(loggingEnabled))
         .get(uri(path, query))
-      .then();
-
-      if (loggingEnabled) {
-        responseSpec.log().everything();
-      }
-
-      return responseSpec
+      .then()
         .contentType(SCIM_MEDIA_TYPE);
+
+    if (loggingEnabled) {
+      responseSpec.log().everything();
+    }
+
+      return responseSpec;
   }
 
   protected ValidatableResponse post(String path, String body) {
     ValidatableResponse responseSpec =
       given()
+        .config(config)
         .urlEncodingEnabled(false) // URL encoding is handled but the URI
         .redirects().follow(false)
         .accept(SCIM_MEDIA_TYPE)
@@ -127,6 +135,7 @@ public class ScimpleITSupport {
   protected ValidatableResponse put(String path, String body) {
     ValidatableResponse responseSpec =
       given()
+        .config(config)
         .urlEncodingEnabled(false) // URL encoding is handled but the URI
         .redirects().follow(false)
         .accept(SCIM_MEDIA_TYPE)
@@ -148,6 +157,7 @@ public class ScimpleITSupport {
   protected ValidatableResponse patch(String path, String body) {
     ValidatableResponse responseSpec =
       given()
+        .config(config)
         .urlEncodingEnabled(false) // URL encoding is handled but the URI
         .redirects().follow(false)
         .accept(SCIM_MEDIA_TYPE)
@@ -169,6 +179,7 @@ public class ScimpleITSupport {
   protected ValidatableResponse delete(String path) {
     ValidatableResponse responseSpec =
       given()
+        .config(config)
         .urlEncodingEnabled(false) // URL encoding is handled but the URI
         .redirects().follow(false)
         .accept(SCIM_MEDIA_TYPE)

--- a/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/UsersIT.java
+++ b/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/UsersIT.java
@@ -59,25 +59,6 @@ public class UsersIT extends ScimpleITSupport {
   }
 
   @Test
-  @DisplayName("Get Users/{{id}}")
-  public void userById() {
-    String id = get("/Users", Map.of("count", "1","startIndex", "1"))
-      .statusCode(200)
-      .extract().jsonPath().get("Resources[0].id");
-
-    get("/Users/" + id)
-      .statusCode(200)
-      .body(
-        "id", is(id),
-        "name.familyName", not(emptyString()),
-        "name.givenName", not(emptyString()),
-        "userName", not(emptyString()),
-        "active", isBoolean(),
-        "emails[0].value", not(emptyString())
-      );
-  }
-
-  @Test
   @DisplayName("Test invalid User by username")
   public void invalidUserNameFilter() {
     String invalidUserName = RandomStringUtils.randomAlphanumeric(10);


### PR DESCRIPTION
This test depended on a precondition of the SCIM server under test, if a user does not exist, or another test caused an issue with the first user returned, the test would fail

UsersIT.createUser() covers this case by creating a user then retrieving that user. This ensure the test doesn't depend on existing state
