### PR TITLE
Fix copypasta for existingGroupFound

### DIFF
--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
@@ -85,9 +85,9 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     }
 
     // check to make sure the group doesn't already exist
-    boolean existingUserFound = groups.values().stream()
+    boolean existingGroupFound = groups.values().stream()
       .anyMatch(group -> resource.getExternalId().equals(group.getExternalId()));
-    if (existingUserFound) {
+    if (existingGroupFound) {
       // HTTP leaking into data layer
       throw new UnableToCreateResourceException(Response.Status.CONFLICT, "Group '" + resource.getExternalId() + "' already exists.");
     }

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
@@ -85,9 +85,9 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     }
 
     // check to make sure the group doesn't already exist
-    boolean existingUserFound = groups.values().stream()
+    boolean existingGroupFound = groups.values().stream()
       .anyMatch(group -> resource.getExternalId().equals(group.getExternalId()));
-    if (existingUserFound) {
+    if (existingGroupFound) {
       // HTTP leaking into data layer
       throw new UnableToCreateResourceException(Response.Status.CONFLICT, "Group '" + resource.getExternalId() + "' already exists.");
     }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -75,9 +75,9 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     }
 
     // check to make sure the group doesn't already exist
-    boolean existingUserFound = groups.values().stream()
+    boolean existingGroupFound = groups.values().stream()
       .anyMatch(group -> resource.getExternalId().equals(group.getExternalId()));
-    if (existingUserFound) {
+    if (existingGroupFound) {
       // HTTP leaking into data layer
       throw new UnableToCreateResourceException(Response.Status.CONFLICT, "Group '" + resource.getExternalId() + "' already exists.");
     }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
@@ -84,9 +84,9 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     }
 
     // check to make sure the group doesn't already exist
-    boolean existingUserFound = groups.values().stream()
+    boolean existingGroupFound = groups.values().stream()
       .anyMatch(group -> resource.getExternalId().equals(group.getExternalId()));
-    if (existingUserFound) {
+    if (existingGroupFound) {
       // HTTP leaking into data layer
       throw new UnableToCreateResourceException(Response.Status.CONFLICT, "Group '" + resource.getExternalId() + "' already exists.");
     }

--- a/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
+++ b/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
@@ -74,9 +74,9 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     }
 
     // check to make sure the group doesn't already exist
-    boolean existingUserFound = groups.values().stream()
+    boolean existingGroupFound = groups.values().stream()
       .anyMatch(group -> resource.getExternalId().equals(group.getExternalId()));
-    if (existingUserFound) {
+    if (existingGroupFound) {
       // HTTP leaking into data layer
       throw new UnableToCreateResourceException(Response.Status.CONFLICT, "Group '" + resource.getExternalId() + "' already exists.");
     }


### PR DESCRIPTION
GroupService classes had a variable `existingUserFound`, when it should be `existingGroupFound`