### PR TITLE
Update to Spring Boot 3.1.2

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -24,7 +24,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.18</version>
+    <version>1.17.4</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
     <version.lombok>1.18.28</version.lombok>
     <version.lombok.plugin>1.18.20.0</version.lombok.plugin>
     <version.restfuse>1.2.0</version.restfuse>
-    <version.slf4j>1.7.36</version.slf4j>
+    <version.slf4j>2.0.7</version.slf4j>
     <version.antlr4>4.13.0</version.antlr4>
     <version.resteasy>6.2.4.Final</version.resteasy>
-    <version.spring-boot>3.0.6</version.spring-boot>
+    <version.spring-boot>3.1.2</version.spring-boot>
 
     <!-- default surefire/failsafe arg lines to empty-->
     <jacoco.argline></jacoco.argline>
@@ -235,12 +235,10 @@
         <artifactId>guava</artifactId>
         <version>32.1.1-android</version>
       </dependency>
-      <!-- later version of logback and other deps in the examples don't play well together,
-           this version works seems to work with Spring, Jersey, and embedded examples -->
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.11</version>
+        <version>1.4.8</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/scim-compliance-tests/pom.xml
+++ b/scim-compliance-tests/pom.xml
@@ -39,6 +39,12 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <!-- Required for any libraries that expect to call the commons logging APIs -->

--- a/support/spring-boot/pom.xml
+++ b/support/spring-boot/pom.xml
@@ -103,13 +103,5 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- TODO: Spring pulls in an older version of logback-classic, using newer versions fails to start -->
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.2.11</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
- Revert to gradle-ext 1.17.x until ge.apache.org is updated
- Update to Spring Boot 3.1.2 & newer SLF4J
