### PR TITLE
GroupIds and module names now match project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Apache Directory SCIMple
 ========================
 
-Apache's Java EE implementation of the [Simple Cross-domain Identity Management](http://www.simplecloud.info/) (SCIM) version 2.0 specification as defined by the following RFCs:
+Jakarta EE implementation of the [Simple Cross-domain Identity Management](http://www.simplecloud.info/) (SCIM) version 2.0 specification as defined by the following RFCs:
 
 * [RFC7643 - SCIM: Core Schema](https://tools.ietf.org/html/rfc7643)
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <version>47</version>
   </parent>
 
-  <groupId>org.apache.directory.scim</groupId>
+  <groupId>org.apache.directory.scimple</groupId>
   <artifactId>scim-parent</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>SCIM - Parent</name>
-  <description>Apache Directory SCIMple - JavaEE implementation of the SCIM version 2.0 specification (RFC7642, RFC7643 and RFC7644)</description>
+  <name>SCIMple - Parent</name>
+  <description>Apache Directory SCIMple - Jakarta EE implementation of the SCIM version 2.0 specification (RFC7642, RFC7643 and RFC7644)</description>
   <url>https://github.com/apache/directory-scimple</url>
 
   <properties>
@@ -120,42 +120,43 @@
     <dependencies>
       <!-- Project Modules -->
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-spec-protocol</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-spec-schema</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-core</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-tools</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-server</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-client</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-compliance-tests</artifactId>
         <version>1.0.0-SNAPSHOT</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.directory.scim</groupId>
+        <groupId>org.apache.directory.scimple</groupId>
         <artifactId>scim-spring-boot-starter</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
@@ -566,7 +567,7 @@
                 <include>**/*IT.java</include>
               </includes>
               <dependenciesToScan>
-                <dependency>org.apache.directory.scim:scim-compliance-tests</dependency>
+                <dependency>org.apache.directory.scimple:scim-compliance-tests</dependency>
               </dependenciesToScan>
             </configuration>
           </plugin>

--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -18,12 +18,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim-client</artifactId>
-  <name>SCIM - Client</name>
+  <name>SCIMple - Client</name>
 
   <properties>
     <module.name>org.apache.directory.scim.client</module.name>
@@ -31,15 +31,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-protocol</artifactId>
     </dependency>
     <dependency>

--- a/scim-compliance-tests/pom.xml
+++ b/scim-compliance-tests/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-compliance-tests</artifactId>
-  <name>SCIM - Compliance Tests</name>
+  <name>SCIMple - Compliance Tests</name>
 
   <properties>
     <module.name>org.apache.directory.scim.compliance</module.name>

--- a/scim-core/pom.xml
+++ b/scim-core/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-core</artifactId>
-  <name>SCIM - Core</name>
+  <name>SCIMple - Core</name>
 
   <properties>
     <module.name>org.apache.directory.scim.core</module.name>
@@ -33,7 +33,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>

--- a/scim-coverage/pom.xml
+++ b/scim-coverage/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-test-coverage</artifactId>
-  <name>SCIM - Total Test Coverage</name>
+  <name>SCIMple - Total Test Coverage</name>
   <packaging>pom</packaging>
 
   <properties>
@@ -35,31 +35,31 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-protocol</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-tools</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spring-boot-starter</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-client</artifactId>
     </dependency>
   </dependencies>

--- a/scim-server-examples/scim-server-jersey/pom.xml
+++ b/scim-server-examples/scim-server-jersey/pom.xml
@@ -18,14 +18,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-jersey</artifactId>
-  <name>SCIM - Server - Examples - Jersey</name>
+  <name>SCIMple - Server - Examples - Jersey</name>
 
   <properties>
     <module.name>org.apache.directory.scim.example.jersey</module.name>
@@ -79,7 +79,7 @@
       <artifactId>jakarta.enterprise.lang-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-server</artifactId>
     </dependency>
 
@@ -99,7 +99,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-compliance-tests</artifactId>
       <scope>test</scope>
     </dependency>

--- a/scim-server-examples/scim-server-memory/pom.xml
+++ b/scim-server-examples/scim-server-memory/pom.xml
@@ -18,14 +18,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-memory</artifactId>
-  <name>SCIM - Server - Examples - Memory</name>
+  <name>SCIMple - Server - Examples - Memory</name>
   <packaging>war</packaging>
 
   <dependencies>
@@ -46,7 +46,7 @@
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-server</artifactId>
     </dependency>
     <dependency>

--- a/scim-server-examples/scim-server-spring-boot/pom.xml
+++ b/scim-server-examples/scim-server-spring-boot/pom.xml
@@ -18,14 +18,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-spring-boot</artifactId>
-  <name>SCIM - Server - Examples - Spring Boot</name>
+  <name>SCIMple - Server - Examples - Spring Boot</name>
 
   <properties>
     <module.name>org.apache.directory.scim.example.springboot</module.name>
@@ -46,11 +46,11 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spring-boot-starter</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-server</artifactId>
     </dependency>
     <dependency>

--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-server</artifactId>
-  <name>SCIM - Server</name>
+  <name>SCIMple - Server</name>
   <packaging>jar</packaging>
 
   <properties>
@@ -59,15 +59,15 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-protocol</artifactId>
     </dependency>
     <dependency>
@@ -126,7 +126,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-compliance-tests</artifactId>
       <scope>test</scope>
     </dependency>

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -21,14 +21,14 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
 	<artifactId>scim-spec-protocol</artifactId>
-	<name>SCIM - Specification - Protocol</name>
+	<name>SCIMple - Specification - Protocol</name>
 
   <properties>
     <module.name>org.apache.directory.scim.protocol</module.name>
@@ -46,7 +46,7 @@
 			<version>2.2.15</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.directory.scim</groupId>
+			<groupId>org.apache.directory.scimple</groupId>
 			<artifactId>scim-spec-schema</artifactId>
 		</dependency>
 		<dependency>

--- a/scim-spec/scim-spec-schema/pom.xml
+++ b/scim-spec/scim-spec-schema/pom.xml
@@ -19,14 +19,14 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
 	<artifactId>scim-spec-schema</artifactId>
-	<name>SCIM - Specification - Schema</name>
+	<name>SCIMple - Specification - Schema</name>
 
   <properties>
     <module.name>org.apache.directory.scim.spec</module.name>

--- a/scim-tools/pom.xml
+++ b/scim-tools/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>scim-tools</artifactId>
-  <name>SCIM - Tools</name>
+  <name>SCIMple - Tools</name>
 
   <properties>
     <module.name>org.apache.directory.scim.tools</module.name>
@@ -33,7 +33,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-spec-schema</artifactId>
     </dependency>
     <dependency>

--- a/support/spring-boot/pom.xml
+++ b/support/spring-boot/pom.xml
@@ -19,14 +19,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scim</groupId>
+    <groupId>org.apache.directory.scimple</groupId>
     <artifactId>scim-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-spring-boot-starter</artifactId>
-  <name>SCIM - Support - Spring Boot Starter</name>
+  <name>SCIMple - Support - Spring Boot Starter</name>
 
   <properties>
     <module.name>org.apache.directory.scim.spring</module.name>
@@ -65,7 +65,7 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-server</artifactId>
     </dependency>
     <dependency>
@@ -79,7 +79,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.directory.scim</groupId>
+      <groupId>org.apache.directory.scimple</groupId>
       <artifactId>scim-compliance-tests</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Using the groupid of "org.apache.directory.scimple" should make the project more discoverable (e.g. searching from Maven Central)
Project name's now contain "SCIMple" as well
