### PR TITLE
Allow tests to be run with existing server

### DIFF
--- a/scim-compliance-tests/pom.xml
+++ b/scim-compliance-tests/pom.xml
@@ -47,6 +47,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <!-- Required for any libraries that expect to call the commons logging APIs -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>


### PR DESCRIPTION
The EmbeddedServerExtension, now only prints a message when an implementation is not found.

Now you could run tests against any running server by running test directly from your IDE
