### PR TITLE
Refuse APPLICATION_JSON to avoid data loss

### DIFF
--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/BaseResourceTypeResource.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/BaseResourceTypeResource.java
@@ -113,7 +113,7 @@ public interface BaseResourceTypeResource<T> {
    * @return
    */
   @POST
-  @Consumes({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
+  @Consumes(Constants.SCIM_CONTENT_TYPE)
   @Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
   @Operation(description = "Create")
   @ApiResponses(value = {
@@ -160,7 +160,7 @@ public interface BaseResourceTypeResource<T> {
    */
   @PUT
   @Path("{id}")
-  @Consumes({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
+  @Consumes(Constants.SCIM_CONTENT_TYPE)
   @Produces({Constants.SCIM_CONTENT_TYPE, MediaType.APPLICATION_JSON})
   @Operation(description = "Update")
   @ApiResponses(value = {


### PR DESCRIPTION
If APPLICATION_JSON is accepted when posting a SCIM entity, the custom JacksonXmlBindJsonProvider is not used. This is a serious problem, because the REST API appears to work without any errors, but in reality all data relating to the use of a schema extension is lost. This behavior can confuse the user and be very dangerous, it is better to reject the application/json format