### PR TITLE
Restrict ScimJacksonXmlBindJsonProvider to only handling SCIMple classes

### DIFF
--- a/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/UsersIT.java
+++ b/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/UsersIT.java
@@ -188,7 +188,7 @@ public class UsersIT extends ScimpleITSupport {
 
     get("/Users", Map.of("filter", "userName eq \"" + userName + "\""))
       .statusCode(200)
-      .contentType("application/scim+json")
+      .contentType(SCIM_MEDIA_TYPE)
       .body(
         "schemas", contains(SCHEMA_LIST_RESPONSE),
         "totalResults", is(1)


### PR DESCRIPTION
Previously application/json requests may have lost any custom extension data.

This change adds applicaiton/json to the list of supproted media types (as recommended by the SCIM specs), but restricts it's types to ONLY classes known by SCIMple, and allows other MessageBodyReader/Writer to handle other requests

Fixes: #390
