### PR TITLE
Idea: Pass all search information into the repository implementation

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/FindRequest.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/FindRequest.java
@@ -1,0 +1,74 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ 
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.core.repository;
+
+import lombok.Data;
+import org.apache.directory.scim.spec.filter.Filter;
+import org.apache.directory.scim.spec.filter.PageRequest;
+import org.apache.directory.scim.spec.filter.SortOrder;
+import org.apache.directory.scim.spec.filter.SortRequest;
+import org.apache.directory.scim.spec.filter.attribute.AttributeReference;
+
+import java.util.Set;
+
+/**
+ * Holds information about a SCIM query/find/search request.
+ */
+@Data
+public class FindRequest {
+
+  private final Set<AttributeReference> attributes;
+
+  private final Set<AttributeReference> excludedAttributes;
+
+  private final Filter filter;
+
+  private final AttributeReference sortBy;
+
+  private final SortOrder sortOrder;
+
+  private final Integer startIndex;
+
+  private final Integer count;
+
+  public FindRequest(Set<AttributeReference> attributes, Set<AttributeReference> excludedAttributes, Filter filter, AttributeReference sortBy, SortOrder sortOrder, Integer startIndex, Integer count) {
+    this.attributes = attributes;
+    this.excludedAttributes = excludedAttributes;
+    this.filter = filter;
+    this.sortBy = sortBy;
+    this.sortOrder = sortOrder;
+    this.startIndex = startIndex;
+    this.count = count;
+  }
+
+  public PageRequest getPageRequest() {
+    PageRequest pageRequest = new PageRequest();
+    pageRequest.setStartIndex(startIndex);
+    pageRequest.setCount(count);
+    return pageRequest;
+  }
+  
+  public SortRequest getSortRequest() {
+    SortRequest sortRequest = new SortRequest();
+    sortRequest.setSortBy(sortBy);
+    sortRequest.setSortOrder(sortOrder);
+    return sortRequest;
+  }
+}

--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/Repository.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/Repository.java
@@ -98,7 +98,35 @@ public interface Repository<T extends ScimResource> {
    *         cannot be retrieved.
    */
   FilterResponse<T> find(Filter filter, PageRequest pageRequest, SortRequest sortRequest) throws ResourceException;
-  
+
+  /**
+   * Finds and retrieves all ScimResource objects known to the persistence
+   * layer that match the criteria specified by the FindRequest.The results
+   * may be truncated by the scope specified by the passed PageRequest and
+   * the order of the returned resources may be controlled by the passed
+   * SortRequest.
+   * <b>
+   * NOTE: The default implementation of this method ignores the include/exclude attributes.
+   *
+   * @param findRequest the find request that determines the ScimResources that will be
+   *        part of the ResultList
+   * @return A list of the ScimResources that pass the filter criteria,
+   *        truncated to match the requested "page" and sorted according
+   *        to the provided requirements.
+   * @throws ResourceException If one or more ScimResources
+   *         cannot be retrieved.
+   */
+  default FilterResponse<T> find(FindRequest findRequest) throws ResourceException {
+
+    Filter filter = findRequest.getFilter();
+    PageRequest pageRequest = findRequest.getPageRequest();
+    SortRequest sortRequest = findRequest.getSortRequest();
+
+    // TODO: Implement the include/exclude attributes, this is currently done in BaseResourceTypeResourceImpl
+    // it calculates the etag before excluding attributes, that logic may need to move to this layer?
+    return find(filter, pageRequest, sortRequest);
+  }
+
   /**
    * Deletes the ScimResource with the provided identifier (if it exists).
    * This interface makes no distinction between hard and soft deletes but

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/BaseResourceTypeResourceImpl.java
@@ -34,6 +34,7 @@ import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.Response.Status.Family;
 
+import org.apache.directory.scim.core.repository.FindRequest;
 import org.apache.directory.scim.protocol.exception.ScimException;
 import org.apache.directory.scim.server.exception.*;
 import org.apache.directory.scim.core.repository.RepositoryRegistry;
@@ -224,7 +225,8 @@ public abstract class BaseResourceTypeResourceImpl<T extends ScimResource> imple
 
     ListResponse<T> listResponse = new ListResponse<>();
 
-    FilterResponse<T> filterResp = repository.find(filter, pageRequest, sortRequest);
+    FindRequest findRequest = new FindRequest(attributeReferences, excludedAttributeReferences, filter, sortRequest.getSortBy(), sortRequest.getSortOrder(), pageRequest.getStartIndex(), pageRequest.getCount());
+    FilterResponse<T> filterResp = repository.find(findRequest);
 
     // If no resources are found, we should still return a ListResponse with
     // the totalResults set to 0;


### PR DESCRIPTION
This change is backward compatible, but it's possible this should be a breaking change, and force implementations to use this method, instead of the other?
When developer overrides this method, the original `find` method must still be defined, but is not used.

Questions:
-  I'm not really a fan of the FindRequest nameing, `SearchRequest` or `QueryRequest` might work better, but `SearchRequest` is used at the REST layer, so I didn't thing we should have two classes named `SearchRequest` (maybe we should rename the other...)
- Backwards compatibilty, should we break this? (the migration guide would be simple)
- Passing the exclude args down the the search is probably the right thing to do, but that potentially changes the meaning of the etag,  this is currently done at the REST layer, but maybe this should move down a layer?  We could still handle this by default 🤷

We probably need to dig into how the etag should work when attributes are included/excluded
