### PR TITLE
[SCIMPLE-93] Set type=reference, when referenceTypes are set

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
@@ -203,8 +203,15 @@ public final class Schemas {
         case STRING_TYPE_IDENTIFIER:
         case CHARACTER_ARRAY_TYPE_IDENTIFIER:
         case BIG_C_CHARACTER_ARRAY_TYPE_IDENTIFIER:
-          log.debug("Setting type to String");
-          attribute.setType(Schema.Attribute.Type.STRING);
+        case RESOURCE_REFERENCE_TYPE_IDENTIFIER:
+          // Check whether referenceTypes were not set. The default value is [""]
+          if (sa.referenceTypes().length == 1 && sa.referenceTypes()[0].isEmpty()) {
+            log.debug("Setting type to String");
+            attribute.setType(Schema.Attribute.Type.STRING);
+          } else {
+            log.debug("Setting type to reference");
+            attribute.setType(Schema.Attribute.Type.REFERENCE);
+          }
           attributeIsAString = true;
           break;
         case INT_TYPE_IDENTIFIER:
@@ -234,10 +241,6 @@ public final class Schemas {
         case LOCAL_DATE_TYPE_IDENTIFER:
           log.debug("Setting type to date time");
           attribute.setType(Schema.Attribute.Type.DATE_TIME);
-          break;
-        case RESOURCE_REFERENCE_TYPE_IDENTIFIER:
-          log.debug("Setting type to reference");
-          attribute.setType(Schema.Attribute.Type.REFERENCE);
           break;
         default:
           log.debug("Setting type to complex");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SCIMPLE-93

Fields that have `referenceTypes` set should have type `reference`. Previously we set type=reference for field `type`, but it should be on field `ref`
```
          {
            "name" : "value",
            "type" : "reference",
            "referenceTypes" : ["external"],
            "multiValued" : false,
            "description" : "URL of a photo of the User.",
            "required" : false,
            "caseExact" : false,
            "mutability" : "readWrite",
            "returned" : "default",
            "uniqueness" : "none"
          },
```
source: https://datatracker.ietf.org/doc/html/rfc7643#section-8.7.1 (page 59)

> A reference has a "referenceTypes" attribute...
> ...
> By convention, a reference is commonly represented as a "$ref" sub-attribute in complex or multi-valued attributes; however, this is OPTIONAL.

source: https://datatracker.ietf.org/doc/html/rfc7643#section-2.3.7

The condition is not very nice, since the default is a list with one empty string...