### PR TITLE
Add `name="$ref"` to ScimAttribute, where it's set in XmlElement

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/extension/EnterpriseExtension.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/extension/EnterpriseExtension.java
@@ -54,7 +54,7 @@ public class EnterpriseExtension implements ScimExtension {
     @XmlElement
     private String value;
 
-    @ScimAttribute(description = "The URI of the SCIM resource representing the User's manager.  RECOMMENDED.")
+    @ScimAttribute(name="$ref", description = "The URI of the SCIM resource representing the User's manager.  RECOMMENDED.")
     @XmlElement(name="$ref")
     private String ref;
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceReference.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceReference.java
@@ -52,7 +52,7 @@ public class ResourceReference implements Serializable {
   @XmlElement
   String value;
 
-  @ScimAttribute(description="The URI of the corresponding resource ", referenceTypes={"User", "Group"})
+  @ScimAttribute(name = "$ref", description="The URI of the corresponding resource ", referenceTypes={"User", "Group"})
   @XmlElement(name = "$ref")
   String ref;
 


### PR DESCRIPTION
`@XmlElement(name="$ref")` doesn't propagate to `/Schemas` endpoint.

It might also be possible to change the name resolution
1. name from ScimAttribute
2. name from XmlElement
3. name of the field