### PR TITLE
Handle Azure style Group member remove operations

### DIFF
--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -29,11 +29,11 @@ import org.apache.directory.scim.spec.patch.PatchOperationPath;
 import org.apache.directory.scim.spec.phonenumber.PhoneNumberParseException;
 import org.apache.directory.scim.spec.resources.Address;
 import org.apache.directory.scim.spec.resources.Email;
+import org.apache.directory.scim.spec.resources.GroupMembership;
 import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.PhoneNumber;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.apache.directory.scim.spec.resources.ScimUser;
-import org.apache.directory.scim.spec.schema.ResourceReference;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.directory.scim.spec.patch.PatchOperation.Type.*;
@@ -51,6 +51,7 @@ public class PatchHandlerTest {
   public PatchHandlerTest() {
     SchemaRegistry schemaRegistry = new SchemaRegistry();
     schemaRegistry.addSchema(ScimUser.class, List.of(EnterpriseExtension.class));
+    schemaRegistry.addSchema(ScimGroup.class, null);
     this.patchHandler = new DefaultPatchHandler(schemaRegistry);
   }
 
@@ -666,8 +667,8 @@ public class PatchHandlerTest {
   }
 
   private static ScimGroup group() {
-    ResourceReference member1 = userRef("1234");
-    ResourceReference member2 = userRef("5678");
+    GroupMembership member1 = userRef("1234");
+    GroupMembership member2 = userRef("5678");
 
     return new ScimGroup()
       .setDisplayName("Test Group")
@@ -675,9 +676,9 @@ public class PatchHandlerTest {
       .setMembers(List.of(member1, member2));
   }
 
-  private static ResourceReference userRef(String id) {
-    ResourceReference member = new ResourceReference();
-    member.setType(ResourceReference.ReferenceType.USER);
+  private static GroupMembership userRef(String id) {
+    GroupMembership member = new GroupMembership();
+    member.setType(GroupMembership.Type.USER);
     member.setValue(id);
     member.setRef("https://example.com/Users/" + id);
     member.setDisplay("Test User" + id);

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.directory.scim.spec.patch.PatchOperation.Type.*;
 import static java.util.Map.entry;
+import static org.apache.directory.scim.test.assertj.ScimpleAssertions.scimAssertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -480,8 +481,15 @@ public class PatchHandlerTest {
         "type", "User")
     ));
 
+    GroupMembership member1 = userRef("1234");
+    GroupMembership member2 = userRef("5678");
+    GroupMembership member3 = new GroupMembership()
+      .setValue("9876")
+      .setDisplay("testUser2")
+      .setType(GroupMembership.Type.USER);
+
     ScimGroup updatedGroup = patchHandler.apply(group(), List.of(op));
-    assertThat(updatedGroup.getMembers().size()).isEqualTo(3);
+    scimAssertThat(updatedGroup).containsOnlyMembers(member1, member2, member3);
   }
 
   /**


### PR DESCRIPTION
Azure sends PATCH operations to remove members from a group of the following form:
```
{
   "schemas":[
      "urn:ietf:params:scim:api:messages:2.0:PatchOp"
   ],
   "Operations":[
      {
         "op":"remove",
         "path":"members",
         "value":[
            {
               "value":"aaebb169-b91d-481c-9957-097faeaf649a"
            }
         ]
      }
   ]
}
```
This is not how the SCIM spec says how to remove a single member from a group, but should be easy enough to handle this case of request.

This PR adds a special case in the `DefaultPatchHandler` to convert these requests to the acceptable and spec-compliant form.