### PR TITLE
Add test for Schema generation from Annotations

### DIFF
--- a/scim-server/src/test/java/org/apache/directory/scim/server/rest/BulkResourceImplTest.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/rest/BulkResourceImplTest.java
@@ -30,10 +30,10 @@ import org.apache.directory.scim.protocol.data.BulkOperation;
 import org.apache.directory.scim.protocol.data.BulkRequest;
 import org.apache.directory.scim.protocol.data.BulkResponse;
 import org.apache.directory.scim.protocol.data.ErrorResponse;
+import org.apache.directory.scim.spec.resources.GroupMembership;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
-import org.apache.directory.scim.spec.schema.ResourceReference;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -60,8 +60,8 @@ public class BulkResourceImplTest {
 
     ScimGroup tourGuides = new ScimGroup()
       .setDisplayName("Tour Guides")
-      .setMembers(List.of(new ResourceReference()
-        .setType(ResourceReference.ReferenceType.USER)
+      .setMembers(List.of(new GroupMembership()
+        .setType(GroupMembership.Type.USER)
         .setValue("bulkId:qwerty")));
 
     BulkRequest bulkRequest = new BulkRequest()

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/GroupMembership.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/GroupMembership.java
@@ -1,0 +1,70 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ 
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.spec.resources;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
+import org.apache.directory.scim.spec.annotation.ScimResourceIdReference;
+import org.apache.directory.scim.spec.schema.Schema;
+
+import java.io.Serializable;
+
+@Data
+@XmlType(propOrder = {"value","ref","display","type"})
+@XmlAccessorType(XmlAccessType.NONE)
+public class GroupMembership implements Serializable {
+
+  private static final long serialVersionUID = 9126588075353486789L;
+
+  @XmlEnum
+  public enum Type {
+    @XmlEnumValue("User") USER,
+    @XmlEnumValue("Group") GROUP;
+  }
+  
+  @ScimAttribute(description="Identifier of the member of this Group.",
+    mutability = Schema.Attribute.Mutability.IMMUTABLE)
+  @ScimResourceIdReference
+  @XmlElement
+  String value;
+
+  @ScimAttribute(name = "$ref", description="The URI corresponding to a SCIM resource that is a member of this Group.",
+    referenceTypes={"User", "Group"},
+    mutability = Schema.Attribute.Mutability.IMMUTABLE)
+  @XmlElement(name = "$ref")
+  String ref;
+
+  @ScimAttribute(description="A human readable name, primarily used for display purposes.",
+    mutability = Schema.Attribute.Mutability.READ_ONLY)
+  @XmlElement
+  String display;
+
+  @ScimAttribute(description="A label indicating the type of resource, e.g., 'User' or 'Group'.",
+    canonicalValueList={"User", "Group"},
+    mutability = Schema.Attribute.Mutability.IMMUTABLE)
+  @XmlElement
+  Type type;
+}

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
@@ -35,7 +35,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.annotation.ScimResourceType;
 import org.apache.directory.scim.spec.schema.Meta;
-import org.apache.directory.scim.spec.schema.ResourceReference;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -56,13 +55,13 @@ public class ScimGroup extends ScimResource implements Serializable {
   
   @XmlElement
   @ScimAttribute(description = "A list of members of the Group.")
-  List<ResourceReference> members;
+  List<GroupMembership> members;
 
-  public ScimGroup addMember(ResourceReference resourceReference) {
+  public ScimGroup addMember(GroupMembership groupMembership) {
     if (members == null) {
       members = new ArrayList<>();
     }
-    members.add(resourceReference);
+    members.add(groupMembership);
 
     return this;
   }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
@@ -35,7 +35,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.annotation.ScimResourceType;
 import org.apache.directory.scim.spec.schema.Meta;
-import org.apache.directory.scim.spec.schema.ResourceReference;
 import org.apache.directory.scim.spec.schema.Schema.Attribute.Returned;
 import org.apache.directory.scim.spec.schema.Schema.Attribute.Uniqueness;
 
@@ -77,7 +76,7 @@ public class ScimUser extends ScimResource implements Serializable {
 
   @XmlElement
   @ScimAttribute(description="A list of groups that the user belongs to, either thorough direct membership, nested groups, or dynamically calculated")
-  List<ResourceReference> groups;
+  List<UserGroup> groups;
 
   @XmlElement
   @ScimAttribute(description="Instant messaging address for the User.")

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/UserGroup.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/UserGroup.java
@@ -17,9 +17,7 @@
 * under the License.
 */
 
-package org.apache.directory.scim.spec.schema;
-
-import java.io.Serializable;
+package org.apache.directory.scim.spec.resources;
 
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -27,40 +25,46 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlEnum;
 import jakarta.xml.bind.annotation.XmlEnumValue;
 import jakarta.xml.bind.annotation.XmlType;
-
+import lombok.Data;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.annotation.ScimResourceIdReference;
-import lombok.Data;
+import org.apache.directory.scim.spec.schema.Schema;
+
+import java.io.Serializable;
 
 @Data
 @XmlType(propOrder = {"value","ref","display","type"})
 @XmlAccessorType(XmlAccessType.NONE)
-public class ResourceReference implements Serializable {
+public class UserGroup implements Serializable {
 
   private static final long serialVersionUID = 9126588075353486789L;
 
   @XmlEnum
-  public enum ReferenceType {
+  public enum Type {
     @XmlEnumValue("direct") DIRECT,
-    @XmlEnumValue("indirect") INDIRECT,
-    @XmlEnumValue("User") USER,
-    @XmlEnumValue("Group") GROUP;
+    @XmlEnumValue("indirect") INDIRECT;
   }
   
-  @ScimAttribute(description="Reference Element Identifier")
+  @ScimAttribute(description="The identifier of the User's group.",
+    mutability = Schema.Attribute.Mutability.READ_ONLY)
   @ScimResourceIdReference
   @XmlElement
   String value;
 
-  @ScimAttribute(name = "$ref", description="The URI of the corresponding resource ", referenceTypes={"User", "Group"})
+  @ScimAttribute(name = "$ref", description="The URI of the corresponding 'Group' resource to which the user belongs.",
+    referenceTypes={"User", "Group"},
+    mutability = Schema.Attribute.Mutability.READ_ONLY)
   @XmlElement(name = "$ref")
   String ref;
 
-  @ScimAttribute(description="A human readable name, primarily used for display purposes. READ-ONLY.")
+  @ScimAttribute(description="A human-readable name, primarily used for display purposes.",
+    mutability = Schema.Attribute.Mutability.READ_ONLY)
   @XmlElement
   String display;
 
-  @ScimAttribute(description="A label indicating the attribute's function; e.g., 'direct' or 'indirect'.", canonicalValueList={"direct", "indirect"})
+  @ScimAttribute(description="A label indicating the attribute's function, e.g., 'direct' or 'indirect'.",
+    canonicalValueList={"direct", "indirect"},
+    mutability = Schema.Attribute.Mutability.READ_ONLY)
   @XmlElement
-  ReferenceType type;
+  Type type;
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
@@ -33,29 +33,33 @@ import org.apache.directory.scim.spec.resources.ScimResource;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.*;
 
 @Slf4j
 public final class Schemas {
-
-  private static final String STRING_TYPE_IDENTIFIER = "class java.lang.String";
-  private static final String STRING_TYPE = "java.lang.String"; // TODO this is ugly
-  private static final String CHARACTER_ARRAY_TYPE_IDENTIFIER = "class [C";
-  private static final String BIG_C_CHARACTER_ARRAY_TYPE_IDENTIFIER = "class [Ljava.lang.Character;";
-  private static final String INT_TYPE_IDENTIFIER = "int";
-  private static final String INTEGER_TYPE_IDENTIFIER = "class java.lang.Integer";
-  private static final String FLOAT_TYPE_IDENTIFIER = "float";
-  private static final String BIG_F_FLOAT_TYPE_IDENTIFIER = "class java.lang.Float";
-  private static final String DOUBLE_TYPE_IDENTIFIER = "double";
-  private static final String BIG_D_DOUBLE_TYPE_IDENTIFIER = "class java.lang.Double";
-  private static final String BOOLEAN_TYPE_IDENTIFIER = "boolean";
-  private static final String BIG_B_BOOLEAN_TYPE_IDENTIFIER = "class java.lang.Boolean";
-  private static final String LOCAL_TIME_TYPE_IDENTIFER = "class java.time.LocalTime";
-  private static final String LOCAL_DATE_TYPE_IDENTIFER = "class java.time.LocalDate";
-  private static final String LOCAL_DATE_TIME_TYPE_IDENTIFIER = "class java.time.LocalDateTime";
-  private static final String DATE_TYPE_IDENTIFIER = "class java.util.Date";
-  private static final String BYTE_ARRAY_TYPE_IDENTIFIER = "class [B";
-  private static final String RESOURCE_REFERENCE_TYPE_IDENTIFIER = "class org.apache.directory.scim.spec.schema.ResourceReference$ReferenceType";
+  private final static Map<Class<?>, Schema.Attribute.Type> CLASS_TO_TYPE = new HashMap<>() {{
+    put(String.class, Schema.Attribute.Type.STRING);
+    put(Character.class, Schema.Attribute.Type.STRING);
+    put(Integer.class, Schema.Attribute.Type.INTEGER);
+    put(int.class, Schema.Attribute.Type.INTEGER);
+    put(Double.class, Schema.Attribute.Type.DECIMAL);
+    put(double.class, Schema.Attribute.Type.DECIMAL);
+    put(Float.class, Schema.Attribute.Type.DECIMAL);
+    put(float.class, Schema.Attribute.Type.DECIMAL);
+    put(Boolean.class, Schema.Attribute.Type.BOOLEAN);
+    put(boolean.class, Schema.Attribute.Type.BOOLEAN);
+    put(LocalTime.class, Schema.Attribute.Type.DATE_TIME);
+    put(LocalDate.class, Schema.Attribute.Type.DATE_TIME);
+    put(LocalDateTime.class, Schema.Attribute.Type.DATE_TIME);
+    put(Date.class, Schema.Attribute.Type.DATE_TIME);
+    put(Instant.class, Schema.Attribute.Type.DATE_TIME);
+    put(byte[].class, Schema.Attribute.Type.BINARY);
+    put(ResourceReference.ReferenceType.class, Schema.Attribute.Type.REFERENCE);
+  }};
 
   private Schemas() {}
 
@@ -120,7 +124,7 @@ public final class Schemas {
 
       log.debug("++++++++++++++++++++ Processing field " + f.getName());
       if (sa == null) {
-        log.debug("Attribute " + f.getName() + " did not have a ScimAttribute annotation");
+        log.debug("Attribute {} did not have a ScimAttribute annotation", f.getName());
         continue;
       }
 
@@ -146,7 +150,7 @@ public final class Schemas {
 
       List<String> canonicalTypes = null;
       Field [] enumFields = sa.canonicalValueEnum().getFields();
-      log.debug("Gathered fields of off the enum, there are " + enumFields.length + " " + sa.canonicalValueEnum().getName());
+      log.debug("Gathered fields of off the enum, there are {} {}", enumFields.length, sa.canonicalValueEnum().getName());
 
       if (enumFields.length != 0) {
 
@@ -174,79 +178,39 @@ public final class Schemas {
       if (canonicalTypes.isEmpty() || (canonicalTypes.size() == 1 && canonicalTypes.get(0).isEmpty())) {
         attribute.setCanonicalValues(null);
       } else {
-        attribute.setCanonicalValues(new HashSet<String>(canonicalTypes));
+        attribute.setCanonicalValues(new HashSet<>(canonicalTypes));
       }
 
       attribute.setCaseExact(sa.caseExact());
       attribute.setDescription(sa.description());
 
-      String typeName = null;
+      Class<?> typeClass;
       if (Collection.class.isAssignableFrom(f.getType())) {
-        log.debug("We have a collection");
+        log.debug("Attribute: '{}' is a collection", attributeName);
         ParameterizedType stringListType = (ParameterizedType) f.getGenericType();
-        Class<?> attributeContainedClass = (Class<?>) stringListType.getActualTypeArguments()[0];
-        typeName = attributeContainedClass.getTypeName();
+        typeClass = (Class<?>) stringListType.getActualTypeArguments()[0];
         attribute.setMultiValued(true);
       } else if (f.getType().isArray()) {
-        log.debug("We have an array");
-        Class<?> componentType = f.getType().getComponentType();
-        typeName = componentType.getTypeName();
-        attribute.setMultiValued(true);
+        log.debug("Attribute: '{}' is an array", attributeName);
+        typeClass = f.getType().getComponentType();
+
+        // special case for byte[]
+        if (typeClass == byte.class) {
+          typeClass = byte[].class;
+        } else {
+          attribute.setMultiValued(true);
+        }
       } else {
-        typeName = f.getType().toString();
+        typeClass = f.getType();
         attribute.setMultiValued(false);
       }
 
-      // attribute.setType(sa.type());
-      boolean attributeIsAString = false;
-      log.debug("Attempting to set the attribute type, raw value = " + typeName);
-      switch (typeName) {
-        case STRING_TYPE_IDENTIFIER:
-        case STRING_TYPE:
-        case CHARACTER_ARRAY_TYPE_IDENTIFIER:
-        case BIG_C_CHARACTER_ARRAY_TYPE_IDENTIFIER:
-          log.debug("Setting type to String");
-          attribute.setType(Schema.Attribute.Type.STRING);
-          attributeIsAString = true;
-          break;
-        case INT_TYPE_IDENTIFIER:
-        case INTEGER_TYPE_IDENTIFIER:
-          log.debug("Setting type to integer");
-          attribute.setType(Schema.Attribute.Type.INTEGER);
-          break;
-        case FLOAT_TYPE_IDENTIFIER:
-        case BIG_F_FLOAT_TYPE_IDENTIFIER:
-        case DOUBLE_TYPE_IDENTIFIER:
-        case BIG_D_DOUBLE_TYPE_IDENTIFIER:
-          log.debug("Setting type to decimal");
-          attribute.setType(Schema.Attribute.Type.DECIMAL);
-          break;
-        case BOOLEAN_TYPE_IDENTIFIER:
-        case BIG_B_BOOLEAN_TYPE_IDENTIFIER:
-          log.debug("Setting type to boolean");
-          attribute.setType(Schema.Attribute.Type.BOOLEAN);
-          break;
-        case BYTE_ARRAY_TYPE_IDENTIFIER:
-          log.debug("Setting type to binary");
-          attribute.setType(Schema.Attribute.Type.BINARY);
-          break;
-        case DATE_TYPE_IDENTIFIER:
-        case LOCAL_DATE_TIME_TYPE_IDENTIFIER:
-        case LOCAL_TIME_TYPE_IDENTIFER:
-        case LOCAL_DATE_TYPE_IDENTIFER:
-          log.debug("Setting type to date time");
-          attribute.setType(Schema.Attribute.Type.DATE_TIME);
-          break;
-        case RESOURCE_REFERENCE_TYPE_IDENTIFIER:
-          log.debug("Setting type to reference");
-          attribute.setType(Schema.Attribute.Type.REFERENCE);
-          break;
-        default:
-          log.debug("Setting type to complex");
-          attribute.setType(Schema.Attribute.Type.COMPLEX);
-      }
+      log.debug("Attempting to set the attribute type, raw value = {}", typeClass);
+      Schema.Attribute.Type type = CLASS_TO_TYPE.getOrDefault(typeClass, Schema.Attribute.Type.COMPLEX);
+      attribute.setType(type);
+
       if (f.getAnnotation(ScimResourceIdReference.class) != null) {
-        if (attributeIsAString) {
+        if (type == Schema.Attribute.Type.STRING) {
           attribute.setScimResourceIdReference(true);
         } else {
           log.warn("Field annotated with @ScimResourceIdReference must be a string: {}", f);
@@ -267,7 +231,6 @@ public final class Schemas {
       attribute.setReturned(sa.returned());
       attribute.setUniqueness(sa.uniqueness());
 
-      //if (sa.type().equals(Type.COMPLEX))
       ScimType st = f.getType().getAnnotation(ScimType.class);
 
       if (attribute.getType() == Schema.Attribute.Type.COMPLEX || st != null) {
@@ -291,7 +254,7 @@ public final class Schemas {
     }
 
     attributeList.sort(Comparator.comparing(o -> o.name));
-    log.debug("Returning " + attributeList.size() + " attributes");
+    log.debug("Returning {} attributes", attributeList.size());
     return attributeList;
   }
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
@@ -58,7 +58,6 @@ public final class Schemas {
     put(Date.class, Schema.Attribute.Type.DATE_TIME);
     put(Instant.class, Schema.Attribute.Type.DATE_TIME);
     put(byte[].class, Schema.Attribute.Type.BINARY);
-    put(ResourceReference.ReferenceType.class, Schema.Attribute.Type.REFERENCE);
   }};
 
   private Schemas() {}
@@ -224,6 +223,7 @@ public final class Schemas {
       if (refType.isEmpty() || (refType.size() == 1 && refType.get(0).isEmpty())) {
         attribute.setReferenceTypes(null);
       } else {
+        attribute.setType(Schema.Attribute.Type.REFERENCE);
         attribute.setReferenceTypes(Arrays.asList(sa.referenceTypes()));
       }
 

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/AllSchemaTypesExtension.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/AllSchemaTypesExtension.java
@@ -1,0 +1,153 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.directory.scim.spec;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
+import org.apache.directory.scim.spec.annotation.ScimExtensionType;
+import org.apache.directory.scim.spec.resources.ScimExtension;
+import org.apache.directory.scim.spec.schema.ResourceReference;
+import org.apache.directory.scim.spec.schema.Schema;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * An extension that can be used to validate schema generation for each type of attribute.
+ */
+@XmlRootElement( name = "AllSchemaTypesExtension", namespace = "https://directory.apache.org/scimple/test/extensions" )
+@XmlAccessorType(XmlAccessType.NONE)
+@Data
+@ScimExtensionType(id = AllSchemaTypesExtension.SCHEMA_URN, description="All Schema Attribute Types", name="AllSchemaTypesExtension", required=true)
+public class AllSchemaTypesExtension implements ScimExtension {
+  
+  public static final String  SCHEMA_URN = "urn:mem:params:scim:schemas:extension:AllSchemaTypesExtension";
+
+  @ScimAttribute(description = "One String")
+  @XmlElement
+  private String string1;
+
+  @ScimAttribute(caseExact = true)
+  @XmlElement
+  private String string2;
+
+  @ScimAttribute
+  @XmlElement
+  private List<String> stringList1;
+
+  @ScimAttribute(required = true)
+  @XmlElement
+  private Boolean boolean1;
+
+  @ScimAttribute(uniqueness = Schema.Attribute.Uniqueness.SERVER)
+  @XmlElement
+  private List<Boolean> booleanList1;
+
+  @ScimAttribute(required = true)
+  @XmlElement
+  private boolean boolean2;
+
+  @ScimAttribute(mutability = Schema.Attribute.Mutability.IMMUTABLE)
+  @XmlElement
+  private boolean[] booleanArray1;
+
+  @ScimAttribute
+  @XmlElement
+  private Double decimal1;
+
+  @ScimAttribute(required = true)
+  @XmlElement
+  private double decimal2;
+
+  @ScimAttribute
+  @XmlElement
+  private List<Double> decimalList1;
+
+  @ScimAttribute
+  @XmlElement
+  private double[] decimalArray1;
+
+  @ScimAttribute
+  @XmlElement
+  private Integer integer1;
+
+  @ScimAttribute(required = true)
+  @XmlElement
+  private int integer2;
+
+  @ScimAttribute
+  @XmlElement
+  private List<Integer> integerList1;
+
+  @ScimAttribute
+  @XmlElement
+  private int[] integerArray1;
+
+  @ScimAttribute
+  @XmlElement
+  private Date date1;
+
+  @ScimAttribute
+  @XmlElement
+  private List<Date> dateList1;
+
+  @ScimAttribute
+  @XmlElement
+  private Date[] dateArray1;
+
+  @ScimAttribute
+  @XmlElement
+  private Instant instant1;
+
+  @ScimAttribute
+  @XmlElement
+  private List<Instant> instantList1;
+
+  @ScimAttribute
+  @XmlElement
+  private Instant[] instantArray1;
+
+  @ScimAttribute
+  @XmlElement
+  private byte[] binary1;
+
+  @ScimAttribute
+  @XmlElement
+  private List<byte[]> binaryList1;
+
+  @ScimAttribute
+  @XmlElement
+  private ResourceReference.ReferenceType ref1;
+
+  @ScimAttribute
+  @XmlElement
+  private List<ResourceReference.ReferenceType> refList1;
+
+  @Override
+  public String getUrn() {
+    return SCHEMA_URN;
+  }
+
+}

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/AllSchemaTypesExtension.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/AllSchemaTypesExtension.java
@@ -27,7 +27,6 @@ import lombok.Data;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.annotation.ScimExtensionType;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.schema.ResourceReference;
 import org.apache.directory.scim.spec.schema.Schema;
 
 import java.time.Instant;
@@ -137,13 +136,17 @@ public class AllSchemaTypesExtension implements ScimExtension {
   @XmlElement
   private List<byte[]> binaryList1;
 
-  @ScimAttribute
+  @ScimAttribute(referenceTypes = {"one", "two"})
   @XmlElement
-  private ResourceReference.ReferenceType ref1;
+  private String ref1;
 
-  @ScimAttribute
+  @ScimAttribute(name = "$ref", referenceTypes = {"three", "four"})
   @XmlElement
-  private List<ResourceReference.ReferenceType> refList1;
+  private String ref2;
+
+  @ScimAttribute(referenceTypes = {"one", "two", "three"})
+  @XmlElement
+  private List<String> refList1;
 
   @Override
   public String getUrn() {

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemasTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemasTest.java
@@ -1,0 +1,441 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.spec.schema;
+
+import org.apache.directory.scim.spec.AllSchemaTypesExtension;
+import org.junit.jupiter.api.Test;
+
+public class SchemasTest {
+
+  private Schema schema = Schemas.schemaForExtension(AllSchemaTypesExtension.class);
+
+  @Test
+  public void string1Attribute() {
+    assertThat(schema.getAttribute("string1"))
+      .hasName("string1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.STRING)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("One String")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void string2Attribute() {
+    assertThat(schema.getAttribute("string2"))
+      .hasName("string2")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.STRING)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(true)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void stringListAttribute() {
+    assertThat(schema.getAttribute("stringList1"))
+      .hasName("stringList1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.STRING)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void booleanAttribute_required() {
+    assertThat(schema.getAttribute("boolean1"))
+      .hasName("boolean1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.BOOLEAN)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(true)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void booleanListAttribute_serverUnique() {
+    assertThat(schema.getAttribute("booleanList1"))
+      .hasName("booleanList1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.BOOLEAN)
+      .hasUniqueness(Schema.Attribute.Uniqueness.SERVER)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void boolean2Attribute() {
+    assertThat(schema.getAttribute("boolean2"))
+      .hasName("boolean2")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.BOOLEAN)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(true)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void booleanArray1Attribute() {
+    assertThat(schema.getAttribute("booleanArray1"))
+      .hasName("booleanArray1")
+      .hasMutability(Schema.Attribute.Mutability.IMMUTABLE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.BOOLEAN)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void decimal1Attribute() {
+    assertThat(schema.getAttribute("decimal1"))
+      .hasName("decimal1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DECIMAL)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void decimal2Attribute() {
+    assertThat(schema.getAttribute("decimal2"))
+      .hasName("decimal2")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DECIMAL)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(true)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void decimalList1Attribute() {
+    assertThat(schema.getAttribute("decimalList1"))
+      .hasName("decimalList1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DECIMAL)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void decimalArray1Attribute() {
+    assertThat(schema.getAttribute("decimalArray1"))
+      .hasName("decimalArray1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DECIMAL)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void integer1Attribute() {
+    assertThat(schema.getAttribute("integer1"))
+      .hasName("integer1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.INTEGER)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void integer2Attribute() {
+    assertThat(schema.getAttribute("integer2"))
+      .hasName("integer2")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.INTEGER)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(true)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void integerList1Attribute() {
+    assertThat(schema.getAttribute("integerList1"))
+      .hasName("integerList1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.INTEGER)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void integerArray1Attribute() {
+    assertThat(schema.getAttribute("integerArray1"))
+      .hasName("integerArray1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.INTEGER)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void date1Attribute() {
+    assertThat(schema.getAttribute("date1"))
+      .hasName("date1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DATE_TIME)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void dateList1Attribute() {
+    assertThat(schema.getAttribute("dateList1"))
+      .hasName("dateList1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DATE_TIME)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void dateArray1Attribute() {
+    assertThat(schema.getAttribute("dateArray1"))
+      .hasName("dateArray1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DATE_TIME)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void instant1Attribute() {
+    assertThat(schema.getAttribute("instant1"))
+      .hasName("instant1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DATE_TIME)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void instantList1Attribute() {
+    assertThat(schema.getAttribute("instantList1"))
+      .hasName("instantList1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DATE_TIME)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void instantArray1Attribute() {
+    assertThat(schema.getAttribute("instantArray1"))
+      .hasName("instantArray1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.DATE_TIME)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void binary1Attribute() {
+    assertThat(schema.getAttribute("binary1"))
+      .hasName("binary1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.BINARY)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void ref1Attribute() {
+    assertThat(schema.getAttribute("ref1"))
+      .hasName("ref1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.REFERENCE)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+  @Test
+  public void refList1Attribute() {
+    assertThat(schema.getAttribute("refList1"))
+      .hasName("refList1")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.REFERENCE)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(true)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(null);
+  }
+
+
+  private AttributeAssert assertThat(Schema.Attribute attribute) {
+    return new AttributeAssert(attribute);
+  }
+}

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemasTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemasTest.java
@@ -22,6 +22,8 @@ package org.apache.directory.scim.spec.schema;
 import org.apache.directory.scim.spec.AllSchemaTypesExtension;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 public class SchemasTest {
 
   private Schema schema = Schemas.schemaForExtension(AllSchemaTypesExtension.class);
@@ -414,7 +416,24 @@ public class SchemasTest {
       .isCaseExact(false)
       .hasSubAttributes(null)
       .hasCanonicalValues(null)
-      .hasReferenceTypes(null);
+      .hasReferenceTypes(List.of("one", "two"));
+  }
+
+  @Test
+  public void ref2Attribute() {
+    assertThat(schema.getAttribute("$ref"))
+      .hasName("$ref")
+      .hasMutability(Schema.Attribute.Mutability.READ_WRITE)
+      .hasReturned(Schema.Attribute.Returned.DEFAULT)
+      .hasType(Schema.Attribute.Type.REFERENCE)
+      .hasUniqueness(Schema.Attribute.Uniqueness.NONE)
+      .isMultiValued(false)
+      .hasDescription("")
+      .isRequired(false)
+      .isCaseExact(false)
+      .hasSubAttributes(null)
+      .hasCanonicalValues(null)
+      .hasReferenceTypes(List.of("three", "four"));
   }
 
   @Test
@@ -431,7 +450,7 @@ public class SchemasTest {
       .isCaseExact(false)
       .hasSubAttributes(null)
       .hasCanonicalValues(null)
-      .hasReferenceTypes(null);
+      .hasReferenceTypes(List.of("one", "two", "three"));
   }
 
 

--- a/scim-test/src/main/java/org/apache/directory/scim/test/assertj/ScimGroupAssert.java
+++ b/scim-test/src/main/java/org/apache/directory/scim/test/assertj/ScimGroupAssert.java
@@ -19,8 +19,8 @@
 
 package org.apache.directory.scim.test.assertj;
 
+import org.apache.directory.scim.spec.resources.GroupMembership;
 import org.apache.directory.scim.spec.resources.ScimGroup;
-import org.apache.directory.scim.spec.schema.ResourceReference;
 import org.assertj.core.api.AbstractAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +38,7 @@ public class ScimGroupAssert extends AbstractAssert<ScimGroupAssert, ScimGroup> 
     return this;
   }
 
-  public ScimGroupAssert containsMember(ResourceReference... expected) {
+  public ScimGroupAssert containsMember(GroupMembership... expected) {
     isNotNull();
     assertMembersNotNull();
     assertThat(actual.getMembers()).contains(expected);

--- a/scim-test/src/main/java/org/apache/directory/scim/test/stub/Subobject.java
+++ b/scim-test/src/main/java/org/apache/directory/scim/test/stub/Subobject.java
@@ -23,7 +23,9 @@ import jakarta.xml.bind.annotation.XmlElement;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class Subobject implements Serializable {
 
@@ -52,6 +54,10 @@ public class Subobject implements Serializable {
   @ScimAttribute
   @XmlElement
   private List<String> list2;
+
+  @ScimAttribute
+  @XmlElement
+  private byte[] binary1;
 
   public String getString1() {
     return this.string1;
@@ -107,55 +113,40 @@ public class Subobject implements Serializable {
     return this;
   }
 
-  public boolean equals(final Object o) {
-    if (o == this) return true;
-    if (!(o instanceof Subobject)) return false;
-    final Subobject other = (Subobject) o;
-    if (!other.canEqual((Object) this)) return false;
-    final Object this$string1 = this.getString1();
-    final Object other$string1 = other.getString1();
-    if (this$string1 == null ? other$string1 != null : !this$string1.equals(other$string1)) return false;
-    final Object this$string2 = this.getString2();
-    final Object other$string2 = other.getString2();
-    if (this$string2 == null ? other$string2 != null : !this$string2.equals(other$string2)) return false;
-    final Object this$boolean1 = this.getBoolean1();
-    final Object other$boolean1 = other.getBoolean1();
-    if (this$boolean1 == null ? other$boolean1 != null : !this$boolean1.equals(other$boolean1)) return false;
-    final Object this$boolean2 = this.getBoolean2();
-    final Object other$boolean2 = other.getBoolean2();
-    if (this$boolean2 == null ? other$boolean2 != null : !this$boolean2.equals(other$boolean2)) return false;
-    final Object this$list1 = this.getList1();
-    final Object other$list1 = other.getList1();
-    if (this$list1 == null ? other$list1 != null : !this$list1.equals(other$list1)) return false;
-    final Object this$list2 = this.getList2();
-    final Object other$list2 = other.getList2();
-    if (this$list2 == null ? other$list2 != null : !this$list2.equals(other$list2)) return false;
-    return true;
+  public byte[] getBinary1() {
+    return binary1;
   }
 
-  protected boolean canEqual(final Object other) {
-    return other instanceof Subobject;
+  public Subobject setBinary1(byte[] binary1) {
+    this.binary1 = binary1;
+    return this;
   }
 
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) return true;
+    if (object == null || getClass() != object.getClass()) return false;
+
+    Subobject subobject = (Subobject) object;
+
+    if (!Objects.equals(string1, subobject.string1)) return false;
+    if (!Objects.equals(string2, subobject.string2)) return false;
+    if (!Objects.equals(boolean1, subobject.boolean1)) return false;
+    if (!Objects.equals(boolean2, subobject.boolean2)) return false;
+    if (!Objects.equals(list1, subobject.list1)) return false;
+    if (!Objects.equals(list2, subobject.list2)) return false;
+      return Arrays.equals(binary1, subobject.binary1);
+  }
+
+  @Override
   public int hashCode() {
-    final int PRIME = 59;
-    int result = 1;
-    final Object $string1 = this.getString1();
-    result = result * PRIME + ($string1 == null ? 43 : $string1.hashCode());
-    final Object $string2 = this.getString2();
-    result = result * PRIME + ($string2 == null ? 43 : $string2.hashCode());
-    final Object $boolean1 = this.getBoolean1();
-    result = result * PRIME + ($boolean1 == null ? 43 : $boolean1.hashCode());
-    final Object $boolean2 = this.getBoolean2();
-    result = result * PRIME + ($boolean2 == null ? 43 : $boolean2.hashCode());
-    final Object $list1 = this.getList1();
-    result = result * PRIME + ($list1 == null ? 43 : $list1.hashCode());
-    final Object $list2 = this.getList2();
-    result = result * PRIME + ($list2 == null ? 43 : $list2.hashCode());
+    int result = string1 != null ? string1.hashCode() : 0;
+    result = 31 * result + (string2 != null ? string2.hashCode() : 0);
+    result = 31 * result + (boolean1 != null ? boolean1.hashCode() : 0);
+    result = 31 * result + (boolean2 != null ? boolean2.hashCode() : 0);
+    result = 31 * result + (list1 != null ? list1.hashCode() : 0);
+    result = 31 * result + (list2 != null ? list2.hashCode() : 0);
+    result = 31 * result + Arrays.hashCode(binary1);
     return result;
-  }
-
-  public String toString() {
-    return "Subobject(string1=" + this.getString1() + ", string2=" + this.getString2() + ", boolean1=" + this.getBoolean1() + ", boolean2=" + this.getBoolean2() + ", list1=" + this.getList1() + ", list2=" + this.getList2() + ")";
   }
 }

--- a/scim-tools/src/test/java/org/apache/directory/scim/tools/diff/PatchGeneratorTest.java
+++ b/scim-tools/src/test/java/org/apache/directory/scim/tools/diff/PatchGeneratorTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.directory.scim.spec.resources.GroupMembership;
 import org.apache.directory.scim.test.stub.ExampleObjectExtension;
 import org.apache.directory.scim.test.stub.Subobject;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
@@ -33,7 +34,6 @@ import org.apache.directory.scim.spec.extension.EnterpriseExtension;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension.Manager;
 import org.apache.directory.scim.spec.filter.FilterParseException;
 import org.apache.directory.scim.spec.patch.PatchOperation;
-import org.apache.directory.scim.spec.patch.PatchOperation.Type;
 import org.apache.directory.scim.spec.patch.PatchOperationPath;
 import org.apache.directory.scim.spec.phonenumber.PhoneNumberParseException;
 import org.apache.directory.scim.spec.resources.Address;
@@ -44,7 +44,6 @@ import org.apache.directory.scim.spec.resources.PhoneNumber.GlobalPhoneNumberBui
 import org.apache.directory.scim.spec.resources.Photo;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.apache.directory.scim.spec.resources.ScimUser;
-import org.apache.directory.scim.spec.schema.ResourceReference;
 import org.apache.directory.scim.spec.schema.Schemas;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,7 +90,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-        .matches(Type.ADD, "nickName", "Jon");
+        .matches(PatchOperation.Type.ADD, "nickName", "Jon");
   }
   
   @Test
@@ -104,7 +103,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.ADD, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", ext);
+      .matches(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", ext);
   }
 
   @Test
@@ -117,7 +116,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.ADD, "name.honorificPrefix", "Dr.");
+      .matches(PatchOperation.Type.ADD, "name.honorificPrefix", "Dr.");
   }
 
   @Test
@@ -132,7 +131,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.ADD, "phoneNumbers", mobilePhone);
+      .matches(PatchOperation.Type.ADD, "phoneNumbers", mobilePhone);
   }
   
   /**
@@ -159,7 +158,7 @@ public class PatchGeneratorTest {
     assertThat(operations).hasSize(1);
     PatchOperation operation = operations.get(0);
     assertNotNull(operation.getValue());
-    assertEquals(Type.ADD, operation.getOperation());
+    assertEquals(PatchOperation.Type.ADD, operation.getOperation());
     assertEquals(PhoneNumber.class, operation.getValue().getClass());
   }
   
@@ -188,12 +187,12 @@ public class PatchGeneratorTest {
     
     PatchOperation operation = operations.get(0);
     assertNotNull(operation.getValue());
-    assertEquals(Type.ADD, operation.getOperation());
+    assertEquals(PatchOperation.Type.ADD, operation.getOperation());
     assertEquals(PhoneNumber.class, operation.getValue().getClass());
     
     operation = operations.get(1);
     assertNotNull(operation.getValue());
-    assertEquals(Type.ADD, operation.getOperation());
+    assertEquals(PatchOperation.Type.ADD, operation.getOperation());
     assertEquals(PhoneNumber.class, operation.getValue().getClass());
   }
 
@@ -206,7 +205,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REPLACE, "active", false);
+      .matches(PatchOperation.Type.REPLACE, "active", false);
   }
   
   @Test
@@ -218,7 +217,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REPLACE, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department", "Dept XYZ.");
+      .matches(PatchOperation.Type.REPLACE, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department", "Dept XYZ.");
   }
 
   @Test
@@ -231,7 +230,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REPLACE, "name.familyName", "Nobody");
+      .matches(PatchOperation.Type.REPLACE, "name.familyName", "Nobody");
   }
 
   @Test
@@ -246,8 +245,8 @@ public class PatchGeneratorTest {
 
     // Changing contents of a collection, should REMOVE the old and ADD a new
     scimAssertThat(result).containsOnly(
-        patchOpMatching(Type.REMOVE, "emails[type EQ \"work\"]"),
-        patchOpMatching(Type.ADD, "emails", workEmail));
+        patchOpMatching(PatchOperation.Type.REMOVE, "emails[type EQ \"work\"]"),
+        patchOpMatching(PatchOperation.Type.ADD, "emails", workEmail));
   }
 
   @Test
@@ -259,7 +258,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REMOVE, "userName", null);
+      .matches(PatchOperation.Type.REMOVE, "userName", null);
   }
   
   @Test
@@ -271,7 +270,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REMOVE, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", null);
+      .matches(PatchOperation.Type.REMOVE, "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", null);
   }
 
   @Test
@@ -284,7 +283,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REMOVE, "name.middleName", null);
+      .matches(PatchOperation.Type.REMOVE, "name.middleName", null);
   }
 
   @Test
@@ -296,7 +295,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REMOVE, "name", null);
+      .matches(PatchOperation.Type.REMOVE, "name", null);
   }
 
   @Test
@@ -313,7 +312,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REMOVE, "emails[type EQ \"home\"]", null);
+      .matches(PatchOperation.Type.REMOVE, "emails[type EQ \"home\"]", null);
   }
   
   @Test
@@ -333,7 +332,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(result).single()
-      .matches(Type.REMOVE, "addresses[type EQ \"local\"]", null);
+      .matches(PatchOperation.Type.REMOVE, "addresses[type EQ \"local\"]", null);
   }
   
   @Test
@@ -357,9 +356,9 @@ public class PatchGeneratorTest {
 
     scimAssertThat(result)
       .containsOnly(
-          patchOpMatching(Type.REMOVE, "addresses[type EQ \"work\"]"),
-          patchOpMatching(Type.ADD, "addresses", newWorkAddress),
-          patchOpMatching(Type.ADD, "addresses", localAddress));
+          patchOpMatching(PatchOperation.Type.REMOVE, "addresses[type EQ \"work\"]"),
+          patchOpMatching(PatchOperation.Type.ADD, "addresses", newWorkAddress),
+          patchOpMatching(PatchOperation.Type.ADD, "addresses", localAddress));
   }
   
   @Test
@@ -434,7 +433,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.ADD, "photos", photo)
+      patchOpMatching(PatchOperation.Type.ADD, "photos", photo)
     );
   }
 
@@ -454,7 +453,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.ADD, ExampleObjectExtension.URN + ":list", List.of(FIRST,SECOND))
+      patchOpMatching(PatchOperation.Type.ADD, ExampleObjectExtension.URN + ":list", List.of(FIRST,SECOND))
     );
   }
   
@@ -471,7 +470,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.REMOVE, "photos")
+      patchOpMatching(PatchOperation.Type.REMOVE, "photos")
     );
   }
 
@@ -490,7 +489,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.REMOVE, ExampleObjectExtension.URN + ":list")
+      patchOpMatching(PatchOperation.Type.REMOVE, ExampleObjectExtension.URN + ":list")
     );
   }
   
@@ -511,7 +510,7 @@ public class PatchGeneratorTest {
 
     // Changing content of list should REMOVE old, and ADD new
     scimAssertThat(operations).containsOnly(
-        patchOpMatching(Type.REPLACE, ExampleObjectExtension.URN + ":list", List.of(FIRST,SECOND,FOURTH)));
+        patchOpMatching(PatchOperation.Type.REPLACE, ExampleObjectExtension.URN + ":list", List.of(FIRST,SECOND,FOURTH)));
   }
   
   @Test
@@ -527,8 +526,8 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.ADD, "name.formatted", nickname),
-      patchOpMatching(Type.REMOVE, "nickName", null)
+      patchOpMatching(PatchOperation.Type.ADD, "name.formatted", nickname),
+      patchOpMatching(PatchOperation.Type.REMOVE, "nickName", null)
     );
   }
   
@@ -547,8 +546,8 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.REPLACE, "name.formatted", nickname),
-      patchOpMatching(Type.REPLACE, "nickName", ""));
+      patchOpMatching(PatchOperation.Type.REPLACE, "name.formatted", nickname),
+      patchOpMatching(PatchOperation.Type.REPLACE, "nickName", ""));
   }
   
   @Test
@@ -566,8 +565,8 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.REPLACE, "name.formatted", nickname),
-      patchOpMatching(Type.REMOVE, "nickName"));
+      patchOpMatching(PatchOperation.Type.REPLACE, "name.formatted", nickname),
+      patchOpMatching(PatchOperation.Type.REMOVE, "nickName"));
   }
   
   @Test
@@ -586,8 +585,8 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.ADD, "name.formatted", nickname),
-      patchOpMatching(Type.REPLACE, "nickName", ""));
+      patchOpMatching(PatchOperation.Type.ADD, "name.formatted", nickname),
+      patchOpMatching(PatchOperation.Type.REPLACE, "nickName", ""));
   }
   
   @Test
@@ -605,8 +604,8 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.REMOVE, "name.formatted"),
-      patchOpMatching(Type.REPLACE, "nickName", nickname));
+      patchOpMatching(PatchOperation.Type.REMOVE, "name.formatted"),
+      patchOpMatching(PatchOperation.Type.REPLACE, "nickName", nickname));
   }
   
   @ParameterizedTest
@@ -640,26 +639,26 @@ public class PatchGeneratorTest {
     //  3c Value
     
     List<Condition<PatchOperation>> multipleOps = new ArrayList<>();
-    multipleOps.add(patchOpMatching(Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "A"));
-    multipleOps.add(patchOpMatching(Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "B"));
-    multipleOps.add(patchOpMatching(Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "C"));
+    multipleOps.add(patchOpMatching(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "A"));
+    multipleOps.add(patchOpMatching(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "B"));
+    multipleOps.add(patchOpMatching(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", "C"));
 
-    params.add(new Object[] {List.of(A), emptyList(), List.of(patchOpMatching(Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
-    params.add(new Object[] {List.of(A), null, List.of(patchOpMatching(Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
-    params.add(new Object[] {null, List.of(A), List.of(patchOpMatching(Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A)))});
-    params.add(new Object[] {null, List.of(C,B,A), List.of(patchOpMatching(Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(C,B,A)))});
-    params.add(new Object[] {List.of(A,B,C), emptyList(), List.of(patchOpMatching(Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
-    params.add(new Object[] {List.of(C,B,A), emptyList(), List.of(patchOpMatching(Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
-    params.add(new Object[] {emptyList(), List.of(A), List.of(patchOpMatching(Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A)))});
-    params.add(new Object[] {emptyList(), List.of(C,B,A), List.of(patchOpMatching(Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(C,B,A)))});
+    params.add(new Object[] {List.of(A), emptyList(), List.of(patchOpMatching(PatchOperation.Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
+    params.add(new Object[] {List.of(A), null, List.of(patchOpMatching(PatchOperation.Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
+    params.add(new Object[] {null, List.of(A), List.of(patchOpMatching(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A)))});
+    params.add(new Object[] {null, List.of(C,B,A), List.of(patchOpMatching(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(C,B,A)))});
+    params.add(new Object[] {List.of(A,B,C), emptyList(), List.of(patchOpMatching(PatchOperation.Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
+    params.add(new Object[] {List.of(C,B,A), emptyList(), List.of(patchOpMatching(PatchOperation.Type.REMOVE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list"))});
+    params.add(new Object[] {emptyList(), List.of(A), List.of(patchOpMatching(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A)))});
+    params.add(new Object[] {emptyList(), List.of(C,B,A), List.of(patchOpMatching(PatchOperation.Type.ADD, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(C,B,A)))});
 
-    params.add(new Object[] {List.of(A, B), List.of(B), List.of(patchOpMatching(Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(B)))});
-    params.add(new Object[] {List.of(B, A), List.of(B), List.of(patchOpMatching(Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(B)))});
+    params.add(new Object[] {List.of(A, B), List.of(B), List.of(patchOpMatching(PatchOperation.Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(B)))});
+    params.add(new Object[] {List.of(B, A), List.of(B), List.of(patchOpMatching(PatchOperation.Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(B)))});
     
-    params.add(new Object[] {List.of(B), List.of(A,B), List.of(patchOpMatching(Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A,B)))});
-    params.add(new Object[] {List.of(B), List.of(B,A), List.of(patchOpMatching(Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(B,A)))});
+    params.add(new Object[] {List.of(B), List.of(A,B), List.of(patchOpMatching(PatchOperation.Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A,B)))});
+    params.add(new Object[] {List.of(B), List.of(B,A), List.of(patchOpMatching(PatchOperation.Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(B,A)))});
     
-    params.add(new Object[] {List.of(A), List.of(A,B,C), List.of(patchOpMatching(Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A,B,C)))});
+    params.add(new Object[] {List.of(A), List.of(A,B,C), List.of(patchOpMatching(PatchOperation.Type.REPLACE, "urn:ietf:params:scim:schemas:extension:example:2.0:Object:list", List.of(A,B,C)))});
     
     return params.toArray();
   }
@@ -680,7 +679,7 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).contains(
-        patchOpMatching(Type.REPLACE, ExampleObjectExtension.URN + ":list", List.of("A","Z")));
+        patchOpMatching(PatchOperation.Type.REPLACE, ExampleObjectExtension.URN + ":list", List.of("A","Z")));
   }
   
   @Test
@@ -699,8 +698,8 @@ public class PatchGeneratorTest {
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.REPLACE, "name.formatted", ""),
-      patchOpMatching(Type.ADD, "nickName", nickname));
+      patchOpMatching(PatchOperation.Type.REPLACE, "name.formatted", ""),
+      patchOpMatching(PatchOperation.Type.ADD, "nickName", nickname));
   }
   
   /**
@@ -724,9 +723,9 @@ public class PatchGeneratorTest {
 
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
     scimAssertThat(operations).contains(
-      patchOpMatching(Type.REMOVE, "phoneNumbers[type EQ \"home\"]"),
-      patchOpMatching(Type.REMOVE, "phoneNumbers[type EQ \"work\"]"),
-      patchOpMatching(Type.ADD, "phoneNumbers", workNumber)
+      patchOpMatching(PatchOperation.Type.REMOVE, "phoneNumbers[type EQ \"home\"]"),
+      patchOpMatching(PatchOperation.Type.REMOVE, "phoneNumbers[type EQ \"work\"]"),
+      patchOpMatching(PatchOperation.Type.ADD, "phoneNumbers", workNumber)
     );
   }
 
@@ -742,7 +741,7 @@ public class PatchGeneratorTest {
 
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(group1, group2);
     scimAssertThat(operations).single()
-      .matches(Type.REPLACE, "displayName", "Test Group - updated");
+      .matches(PatchOperation.Type.REPLACE, "displayName", "Test Group - updated");
   }
 
   @Test
@@ -750,19 +749,19 @@ public class PatchGeneratorTest {
     ScimGroup group1 = new ScimGroup();
     group1.setDisplayName("Test Group");
     group1.setMembers(new ArrayList<>());
-    group1.getMembers().add(new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    group1.getMembers().add(new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user1"));
 
     ScimGroup group2 = new ScimGroup();
     group2.setDisplayName("Test Group");
     group2.setMembers(new ArrayList<>());
-    group2.getMembers().add(new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    group2.getMembers().add(new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user1"));
 
-    ResourceReference user2Ref = new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    GroupMembership user2Ref = new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user2");
     group2.getMembers().add(user2Ref);
 
@@ -771,7 +770,7 @@ public class PatchGeneratorTest {
     assertEquals(1, operations.size());
     PatchOperation operation = operations.get(0);
 
-    scimAssertThat(operation).matches(Type.ADD, "members", user2Ref);
+    scimAssertThat(operation).matches(PatchOperation.Type.ADD, "members", user2Ref);
   }
 
   @Test
@@ -779,24 +778,24 @@ public class PatchGeneratorTest {
     ScimGroup group1 = new ScimGroup();
     group1.setDisplayName("Test Group");
     group1.setMembers(new ArrayList<>());
-    group1.getMembers().add(new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    group1.getMembers().add(new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user1"));
 
-    ResourceReference user2Ref = new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    GroupMembership user2Ref = new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user2");
     group1.getMembers().add(user2Ref);
 
     ScimGroup group2 = new ScimGroup();
     group2.setDisplayName("Test Group");
     group2.setMembers(new ArrayList<>());
-    group2.getMembers().add(new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    group2.getMembers().add(new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user1"));
 
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(group1, group2);
-    scimAssertThat(operations).contains(patchOpMatching(Type.REMOVE, "members[value EQ \"user2\"]"));
+    scimAssertThat(operations).contains(patchOpMatching(PatchOperation.Type.REMOVE, "members[value EQ \"user2\"]"));
   }
 
 
@@ -807,24 +806,24 @@ public class PatchGeneratorTest {
     group1.setDisplayName("Test Group");
     group1.setMembers(new ArrayList<>());
 
-    group1.getMembers().add(new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    group1.getMembers().add(new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user1"));
 
     ScimGroup group2 = new ScimGroup();
     group2.setDisplayName("Test Group");
     group2.setMembers(new ArrayList<>());
 
-    ResourceReference user2Ref = new ResourceReference()
-      .setType(ResourceReference.ReferenceType.USER)
+    GroupMembership user2Ref = new GroupMembership()
+      .setType(GroupMembership.Type.USER)
       .setValue("user2");
     group2.getMembers().add(user2Ref);
 
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(group1, group2);
 
     scimAssertThat(operations).containsOnly(
-      patchOpMatching(Type.REMOVE, "members[value EQ \"user1\"]", null),
-      patchOpMatching(Type.ADD, "members", user2Ref)
+      patchOpMatching(PatchOperation.Type.REMOVE, "members[value EQ \"user1\"]", null),
+      patchOpMatching(PatchOperation.Type.ADD, "members", user2Ref)
     );
   }
   
@@ -923,7 +922,7 @@ public class PatchGeneratorTest {
   private List<PatchOperation> createUser1PatchOps() throws FilterParseException {
     List<PatchOperation> patchOperations = new ArrayList<>();
     PatchOperation removePhoneNumberOp = new PatchOperation();
-    removePhoneNumberOp.setOperation(Type.REMOVE);
+    removePhoneNumberOp.setOperation(PatchOperation.Type.REMOVE);
     removePhoneNumberOp.setPath(PatchOperationPath.fromString("phoneNumbers[type eq \"home\"]"));
     patchOperations.add(removePhoneNumberOp);
     return patchOperations;


### PR DESCRIPTION
While working on the PatchGenerator I noticed a bug in the type detection.
This change adds tests and simplifies related logic