### PR TITLE
Allow overriding getters in ServerConfiguration

### DIFF
--- a/scim-server/src/main/java/org/apache/directory/scim/server/configuration/ServerConfiguration.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/configuration/ServerConfiguration.java
@@ -86,7 +86,7 @@ public class ServerConfiguration {
   public BulkConfiguration getBulkConfiguration() {
     BulkConfiguration bulkConfiguration = new BulkConfiguration();
 
-    bulkConfiguration.setSupported(supportsBulk);
+    bulkConfiguration.setSupported(isSupportsBulk());
     bulkConfiguration.setMaxOperations(bulkMaxOperations);
     bulkConfiguration.setMaxPayloadSize(bulkMaxPayloadSize);
 
@@ -94,7 +94,7 @@ public class ServerConfiguration {
   }
 
   public SupportedConfiguration getEtagConfiguration() {
-    return createSupportedConfiguration(supportsETag);
+    return createSupportedConfiguration(isSupportsETag());
 
   }
 
@@ -110,7 +110,7 @@ public class ServerConfiguration {
   }
 
   public SupportedConfiguration getSortConfiguration() {
-    return createSupportedConfiguration(supportsSort);
+    return createSupportedConfiguration(isSupportsSort());
   }
   
   private SupportedConfiguration createSupportedConfiguration(boolean supported) {

--- a/scim-server/src/main/java/org/apache/directory/scim/server/configuration/ServerConfiguration.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/configuration/ServerConfiguration.java
@@ -80,15 +80,15 @@ public class ServerConfiguration {
   }
 
   public SupportedConfiguration getChangePasswordConfiguration() {
-    return createSupportedConfiguration(supportsChangePassword);
+    return createSupportedConfiguration(isSupportsChangePassword());
   }
 
   public BulkConfiguration getBulkConfiguration() {
     BulkConfiguration bulkConfiguration = new BulkConfiguration();
 
     bulkConfiguration.setSupported(isSupportsBulk());
-    bulkConfiguration.setMaxOperations(bulkMaxOperations);
-    bulkConfiguration.setMaxPayloadSize(bulkMaxPayloadSize);
+    bulkConfiguration.setMaxOperations(getBulkMaxOperations());
+    bulkConfiguration.setMaxPayloadSize(getBulkMaxPayloadSize());
 
     return bulkConfiguration;
   }
@@ -100,13 +100,13 @@ public class ServerConfiguration {
 
   public FilterConfiguration getFilterConfiguration() {
     FilterConfiguration filterConfiguration = new FilterConfiguration();
-    filterConfiguration.setSupported(supportsFilter);
-    filterConfiguration.setMaxResults(filterMaxResults);
+    filterConfiguration.setSupported(isSupportsFilter());
+    filterConfiguration.setMaxResults(getFilterMaxResults());
     return filterConfiguration;
   }
 
   public SupportedConfiguration getPatchConfiguration() {
-    return createSupportedConfiguration(supportsPatch);
+    return createSupportedConfiguration(isSupportsPatch());
   }
 
   public SupportedConfiguration getSortConfiguration() {


### PR DESCRIPTION
Bulk, Sorting and Etags are defined optional in the spec. This changes allows subclasses of ServerConfig to disable these features by overwriting the setters.