### PR TITLE
Rename parent artifactId to `scimple`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.apache.directory.scimple</groupId>
-  <artifactId>scim-parent</artifactId>
+  <artifactId>scimple</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SCIMple</name>

--- a/scim-client/pom.xml
+++ b/scim-client/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>scim-client</artifactId>

--- a/scim-compliance-tests/pom.xml
+++ b/scim-compliance-tests/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 

--- a/scim-core/pom.xml
+++ b/scim-core/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 

--- a/scim-coverage/pom.xml
+++ b/scim-coverage/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 

--- a/scim-server-examples/scim-server-jersey/pom.xml
+++ b/scim-server-examples/scim-server-jersey/pom.xml
@@ -19,7 +19,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/scim-server-examples/scim-server-memory/pom.xml
+++ b/scim-server-examples/scim-server-memory/pom.xml
@@ -19,7 +19,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/scim-server-examples/scim-server-quarkus/pom.xml
+++ b/scim-server-examples/scim-server-quarkus/pom.xml
@@ -19,7 +19,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/scim-server-examples/scim-server-spring-boot/pom.xml
+++ b/scim-server-examples/scim-server-spring-boot/pom.xml
@@ -19,7 +19,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 

--- a/scim-spec/scim-spec-protocol/pom.xml
+++ b/scim-spec/scim-spec-protocol/pom.xml
@@ -22,7 +22,7 @@
 
 	<parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/scim-spec/scim-spec-schema/pom.xml
+++ b/scim-spec/scim-spec-schema/pom.xml
@@ -20,7 +20,7 @@
 
 	<parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>

--- a/scim-test/pom.xml
+++ b/scim-test/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 

--- a/scim-tools/pom.xml
+++ b/scim-tools/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
 

--- a/support/spring-boot/pom.xml
+++ b/support/spring-boot/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scim-parent</artifactId>
+    <artifactId>scimple</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>


### PR DESCRIPTION
The name of the parent more reflects the project name, this should also make it easier to find the project on aggregated javadoc sites
