### PR TITLE
Prepping for release

### DIFF
--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -36,11 +36,21 @@ Make sure to have created the .pgpkey in your p.a.o/~ directory and to have adde
 > **NOTE:** You can also store a [GPG key on a Yubikey](https://developer.okta.com/blog/2021/07/07/developers-guide-to-gpg).
 
 ## Release Process
+
 Since we are using Nexus for the release process is as follows (see also [Publishing maven artifacts](https://www.apache.org/dev/publishing-maven-artifacts.html#staging-maven)).
 
 ### Test the Project
+
+You can run a build equivalent to the release process by running:
+
 ```shell
-$ mvn release:prepare -DdryRun=true
+$ ./mvnw clean install -Papache-release --threads=1
+```
+
+Or by using the Release Plugin with the `dryRun` flag:
+
+```shell
+$ ./mvnw release:prepare -DdryRun=true
 ```
 
 Be aware that this phase will ask you about the next version, and most important, for the next SCM tag :

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
   <url>https://github.com/apache/directory-scimple</url>
 
   <properties>
+    <project.build.outputTimestamp>2023-12-19T00:00:00Z</project.build.outputTimestamp>
     <jdk.version>11</jdk.version>
     <max.jdk.version>${jdk.version}</max.jdk.version>
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
@@ -330,6 +331,7 @@
         </executions>
         <configuration>
           <shortRevisionLength>7</shortRevisionLength>
+          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
           <doCheck>false</doCheck>
           <doUpdate>false</doUpdate>
         </configuration>
@@ -606,7 +608,9 @@
               <signTag>true</signTag>
               <autoVersionSubmodules>true</autoVersionSubmodules>
               <preparationGoals>verify</preparationGoals>
-              <arguments>--threads=1</arguments> <!-- the javadoc aggregation is not thread safe -->
+              <!-- the javadoc aggregation is not thread safe -->
+              <!-- generate SHA-512 checksums -->
+              <arguments>--threads=1 -Daether.checksums.algorithms=SHA-512,SHA-1,MD5</arguments>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
- The buildnumber plugin only runs once
- added project.build.outputTimestamp, for the end goal of creating reproducible builds
- generate SHA-512 checksums on deploy
