### PR TITLE
Correct format of scm.developerConnection in root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
   </modules>
 
   <scm>
-    <connection>scm:git:ssh://git@github.com:apache/directory-scimple.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com:apache/directory-scimple.git</developerConnection>
+    <connection>scm:git:https://github.com/apache/directory-scimple.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/apache/directory-scimple.git</developerConnection>
     <url>https://github.com/apache/directory-scimple</url>
   </scm>
 


### PR DESCRIPTION
replaces `:` with a `/`
Also now uses `https` for non-developer connection
