### PR TITLE
Configuring the Release plugin to fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,7 @@
               <!-- the javadoc aggregation is not thread safe -->
               <!-- generate SHA-512 checksums -->
               <arguments>--threads=1 -Daether.checksums.algorithms=SHA-512,SHA-1,MD5</arguments>
+              <mavenExecutorId>forked-path</mavenExecutorId>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
Previous release attempts failed to run the Quarkus tests correctly
The build of the app directory layout was different then when the build runs normally
Forking the build at release time should closer match a normal run
