### PR TITLE
Bugfix subattribute duplication in schema generation

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
@@ -237,7 +237,6 @@ public final class Schemas {
         Class<?> componentType;
         if (!attribute.isMultiValued()) {
           componentType = f.getType();
-          attribute.setSubAttributes(createAttributes(urn, Arrays.asList(f.getType().getDeclaredFields()), invalidAttributes, nameBase + "." + f.getName()), Schema.Attribute.AddAction.APPEND);
         } else if (f.getType().isArray()) {
           componentType = f.getType().getComponentType();
         } else {

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexType.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexType.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.spec;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
+
+@XmlType(name = "complexType")
+@XmlAccessorType(XmlAccessType.NONE)
+@Data
+public class ComplexType {
+
+  @XmlElement
+  @ScimAttribute(description = "First attribute")
+  String firstAttribute;
+}

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexTypeExtension.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexTypeExtension.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.spec;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Data;
+import org.apache.directory.scim.spec.annotation.ScimAttribute;
+import org.apache.directory.scim.spec.annotation.ScimExtensionType;
+import org.apache.directory.scim.spec.resources.ScimExtension;
+
+import static org.apache.directory.scim.spec.ComplexTypeExtension.SCHEMA_URN;
+
+@XmlRootElement(name = "ComplexTypeExtension", namespace = "https://directory.apache.org/scimple/test/extensions")
+@XmlAccessorType(XmlAccessType.NONE)
+@Data
+@ScimExtensionType(id = SCHEMA_URN, description = "Schema with complex type field", name = "ComplexTypeExtension", required = true)
+public class ComplexTypeExtension implements ScimExtension {
+
+  public static final String SCHEMA_URN = "urn:mem:params:scim:schemas:extension:ComplexTypeExtension";
+
+  @ScimAttribute(description = "A complex type")
+  @XmlElement
+  private ComplexType complexType;
+
+  @Override
+  public String getUrn() {
+    return SCHEMA_URN;
+  }
+}

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemasTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemasTest.java
@@ -20,6 +20,8 @@
 package org.apache.directory.scim.spec.schema;
 
 import org.apache.directory.scim.spec.AllSchemaTypesExtension;
+import org.apache.directory.scim.spec.ComplexTypeExtension;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -453,6 +455,26 @@ public class SchemasTest {
       .hasReferenceTypes(List.of("one", "two", "three"));
   }
 
+  @Test
+  public void complexTypeSubAttributesNotDuplicated() {
+    Schema schema = Schemas.schemaForExtension(ComplexTypeExtension.class);
+    Schema.Attribute complexType = schema.getAttribute("complexType");
+
+    Assertions.assertThat((complexType.subAttributes.size())).isEqualTo(1);
+
+    Schema.Attribute firstAttribute = new Schema.Attribute();
+    firstAttribute.setName("firstAttribute");
+    firstAttribute.setUrn(ComplexTypeExtension.SCHEMA_URN);
+    firstAttribute.setType(Schema.Attribute.Type.STRING);
+    firstAttribute.setDescription("First attribute");
+    firstAttribute.setMutability(Schema.Attribute.Mutability.READ_WRITE);
+    firstAttribute.setReturned(Schema.Attribute.Returned.DEFAULT);
+    firstAttribute.setUniqueness(Schema.Attribute.Uniqueness.NONE);
+
+    assertThat(schema.getAttribute("complexType"))
+      .hasName("complexType")
+      .hasSubAttributes(List.of(firstAttribute));
+  }
 
   private AttributeAssert assertThat(Schema.Attribute attribute) {
     return new AttributeAssert(attribute);


### PR DESCRIPTION
Schema generation of complex type attributes was leading to duplicated subattributes. This can be easily illustrated by taking a closer look at the schemas returned by one of the sample servers (```GET http://localhost:8080/v2/Schemas```). The ```meta``` attribute of the ScimUser schema for example has all its subattributes duplicated.

 This PR is adding a test reproducing the bug and a fix in the schema generation.