### PR TITLE
SCIM attributes according to spec

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -67,7 +67,7 @@ public abstract class ScimResource extends BaseResource<ScimResource> implements
   String id;
 
   @XmlElement
-  @ScimAttribute
+  @ScimAttribute(returned = Returned.DEFAULT, caseExact = true, mutability = Schema.Attribute.Mutability.READ_WRITE)
   String externalId;
 
   // TODO - Figure out JAXB equivalent of JsonAnyGetter and JsonAnySetter

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -27,6 +27,7 @@ import org.apache.directory.scim.spec.annotation.ScimExtensionType;
 import org.apache.directory.scim.spec.annotation.ScimResourceType;
 import org.apache.directory.scim.spec.exception.InvalidExtensionException;
 import org.apache.directory.scim.spec.schema.Meta;
+import org.apache.directory.scim.spec.schema.Schema;
 import org.apache.directory.scim.spec.schema.Schema.Attribute.Returned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,7 @@ public abstract class ScimResource extends BaseResource<ScimResource> implements
 
   @XmlElement
   @Size(min = 1)
-  @ScimAttribute(required = true, returned = Returned.ALWAYS, description = "A unique identifier for a SCIM resource as defined by the service provider.")
+  @ScimAttribute(required = true, returned = Returned.ALWAYS, mutability = Schema.Attribute.Mutability.READ_ONLY, uniqueness = Schema.Attribute.Uniqueness.SERVER, description = "A unique identifier for a SCIM resource as defined by the service provider.")
   String id;
 
   @XmlElement

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -67,7 +67,7 @@ public abstract class ScimResource extends BaseResource<ScimResource> implements
   String id;
 
   @XmlElement
-  @ScimAttribute(returned = Returned.DEFAULT, caseExact = true, mutability = Schema.Attribute.Mutability.READ_WRITE)
+  @ScimAttribute(caseExact = true, mutability = Schema.Attribute.Mutability.READ_WRITE)
   String externalId;
 
   // TODO - Figure out JAXB equivalent of JsonAnyGetter and JsonAnySetter

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
@@ -32,6 +32,8 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.directory.scim.spec.adapter.LocalDateTimeAdapter;
 import lombok.Data;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
+import org.apache.directory.scim.spec.schema.Schema.Attribute.Mutability;
+import org.apache.directory.scim.spec.schema.Schema.Attribute.Returned;
 
 /**
  * Defines the structure of the meta attribute for all SCIM resources as defined
@@ -50,25 +52,25 @@ public class Meta implements Serializable {
 
   @XmlElement
   @Size(min = 1)
-  @ScimAttribute(description = "The name of the resource type of the resource.")
+  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, caseExact = true, description = "The name of the resource type of the resource.")
   String resourceType;
   
   @XmlElement
   @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
-  @ScimAttribute(description = "The DateTime that the resource was added to the service provider.")
+  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The DateTime that the resource was added to the service provider.")
   LocalDateTime created;
   
   @XmlElement
   @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
-  @ScimAttribute(description = "The most recent DateTime that the details of this resource were updated at the service provider.")
+  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The most recent DateTime that the details of this resource were updated at the service provider.")
   LocalDateTime lastModified;
   
   @XmlElement
-  @ScimAttribute(description = "The URI of the resource being returned.")
+  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The URI of the resource being returned.")
   String location;
   
   @XmlElement
-  @ScimAttribute(description = "The version of the resource being returned.  This value must be the same as the entity-tag (ETag) HTTP response header")
+  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The version of the resource being returned.  This value must be the same as the entity-tag (ETag) HTTP response header")
   String version;
 
 }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
@@ -33,7 +33,6 @@ import org.apache.directory.scim.spec.adapter.LocalDateTimeAdapter;
 import lombok.Data;
 import org.apache.directory.scim.spec.annotation.ScimAttribute;
 import org.apache.directory.scim.spec.schema.Schema.Attribute.Mutability;
-import org.apache.directory.scim.spec.schema.Schema.Attribute.Returned;
 
 /**
  * Defines the structure of the meta attribute for all SCIM resources as defined
@@ -52,25 +51,25 @@ public class Meta implements Serializable {
 
   @XmlElement
   @Size(min = 1)
-  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, caseExact = true, description = "The name of the resource type of the resource.")
+  @ScimAttribute(mutability = Mutability.READ_ONLY, caseExact = true, description = "The name of the resource type of the resource.")
   String resourceType;
   
   @XmlElement
   @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
-  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The DateTime that the resource was added to the service provider.")
+  @ScimAttribute(mutability = Mutability.READ_ONLY, description = "The DateTime that the resource was added to the service provider.")
   LocalDateTime created;
   
   @XmlElement
   @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
-  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The most recent DateTime that the details of this resource were updated at the service provider.")
+  @ScimAttribute(mutability = Mutability.READ_ONLY, description = "The most recent DateTime that the details of this resource were updated at the service provider.")
   LocalDateTime lastModified;
   
   @XmlElement
-  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The URI of the resource being returned.")
+  @ScimAttribute(mutability = Mutability.READ_ONLY, description = "The URI of the resource being returned.")
   String location;
   
   @XmlElement
-  @ScimAttribute(returned = Returned.DEFAULT, mutability = Mutability.READ_ONLY, description = "The version of the resource being returned.  This value must be the same as the entity-tag (ETag) HTTP response header")
+  @ScimAttribute(mutability = Mutability.READ_ONLY, description = "The version of the resource being returned.  This value must be the same as the entity-tag (ETag) HTTP response header")
   String version;
 
 }


### PR DESCRIPTION
The classes ScimResource and Meta contain fields where the scim attributes are not set according to spec (mutability, case sensitivity and uniqueness).

It's currently not possible to overwrite these attributes in sub classes. 

To be able to provide schemas according to spec this PR is changing the non conforming attributes to values as defined in https://datatracker.ietf.org/doc/html/rfc7643#section-3.1.