### PR TITLE
Fixed Urn validation annotation in BaseResource

### DIFF
--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
@@ -46,8 +46,7 @@ public abstract class BaseResource<SELF extends BaseResource<SELF>> implements S
 
   @XmlElement(name="schemas")
   @Size(min = 1)
-  @Urn
-  Set<String> schemas;
+  Set<@Urn String> schemas;
 
   public BaseResource(@Urn String urn) {
     addSchema(urn);

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/validator/Urn.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/validator/Urn.java
@@ -26,14 +26,15 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 @Constraint(validatedBy = UrnValidator.class)
-@Target( { METHOD, FIELD, PARAMETER })
+@Target( { TYPE_USE, METHOD, FIELD, PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface  Urn 
+public @interface Urn
 {
   String message() default "The urn is malformed";
 	 


### PR DESCRIPTION
The validator validating ``Urn``s is not able to handle the annotated field of type ``Set<String>`` in ``BaseResource``.

 Validation will fail due to missing validator:
``HV000030: No validator could be found for constraint 'org.apache.directory.scim.spec.validator.Urn' validating type 'java.util.Set<java.lang.String>'. Check configuration for 'create.arg0.schemas'``

This PR is making the validation possible by moving the annotation to the collection type (supported starting with bean validation 2.0 https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#container-element-constraints).