### PR TITLE
The javadoc aggregate-jar goal caused release to fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -822,7 +822,6 @@
                 <id>aggregate</id>
                 <goals>
                   <goal>aggregate</goal>
-                  <goal>aggregate-jar</goal>
                 </goals>
                 <configuration>
                   <excludePackageNames>org.apache.directory.scim.example.*,org.apache.directory.scim.test.*</excludePackageNames>


### PR DESCRIPTION
The single jar is a nice to have, and it can run separately if needed

There is an odd interaction with the aggregate-jar goal and the Quarkus extension (used in a server example)
In the interest of time, this goal is removed
