### PR TITLE
Fixing duplication of resource id in location header

### DIFF
--- a/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/GroupsIT.java
+++ b/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/GroupsIT.java
@@ -19,6 +19,7 @@
 
 package org.apache.directory.scim.compliance.tests;
 
+import io.restassured.response.ValidatableResponse;
 import org.apache.directory.scim.compliance.junit.EmbeddedServerExtension;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
@@ -76,6 +77,7 @@ public class GroupsIT extends ScimpleITSupport {
     // retrieve the group by id
     get("/Groups/" + id)
       .statusCode(200)
+      .header("Location", matchesRegex(".*/Groups/" + id))
       .body(
         "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:Group"),
         "id", not(emptyString()),
@@ -160,6 +162,7 @@ public class GroupsIT extends ScimpleITSupport {
 
     // update Group,
     put("/Groups/" + id, updatedBody)
+      .header("Location", matchesRegex(".*/Groups/" + id))
       .statusCode(200)
       .body(
         "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:Group"),
@@ -188,7 +191,7 @@ public class GroupsIT extends ScimpleITSupport {
         "\"path\": \"members[value eq \\\"" + userId + "\\\"]\"" +
       "}]}";
 
-    String id = post("/Groups", body)
+    ValidatableResponse response = post("/Groups", body)
       .statusCode(201)
       .body(
         "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:Group"),
@@ -196,12 +199,14 @@ public class GroupsIT extends ScimpleITSupport {
         "displayName", is(groupName),
         "members[0].value", is(userId),
         "members[0].display", is(email)
-      )
-      .extract().jsonPath().get("id");
+      );
+    String id = response.extract().jsonPath().get("id");
+    response.header("Location", matchesRegex(".*/Groups/" + id));
 
     // update Group,
     patch("/Groups/" + id, patchBody)
       .statusCode(200)
+      .header("Location", matchesRegex(".*/Groups/" + id))
       .body(
         "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:Group"),
         "members", empty()

--- a/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/UsersIT.java
+++ b/scim-compliance-tests/src/main/java/org/apache/directory/scim/compliance/tests/UsersIT.java
@@ -19,6 +19,7 @@
 
 package org.apache.directory.scim.compliance.tests;
 
+import io.restassured.response.ValidatableResponse;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.directory.scim.compliance.junit.EmbeddedServerExtension;
 import org.junit.jupiter.api.DisplayName;
@@ -103,7 +104,7 @@ public class UsersIT extends ScimpleITSupport {
         "\"active\":true" +
         "}";
 
-    String id = post("/Users", body)
+    ValidatableResponse response = post("/Users", body)
       .statusCode(201)
       .body(
         "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:User"),
@@ -112,12 +113,15 @@ public class UsersIT extends ScimpleITSupport {
         "name.givenName", is(givenName),
         "name.familyName", is(familyName),
         "userName", equalToIgnoringCase(email)
-      )
-      .extract().jsonPath().get("id");
+      );
+
+    String id = response.extract().jsonPath().get("id");
+    response.header("Location", matchesRegex(".*/Users/" + id));
 
     // retrieve the user by id
     get("/Users/" + id)
       .statusCode(200)
+      .header("Location", matchesRegex(".*/Users/" + id))
       .body(
         "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:User"),
         "active", is(true),
@@ -168,6 +172,7 @@ public class UsersIT extends ScimpleITSupport {
 
     put("/Users/" + id, updatedBody)
       .statusCode(200)
+      .header("Location", matchesRegex(".*/Users/" + id))
       .body(
         "schemas", contains("urn:ietf:params:scim:schemas:core:2.0:User"),
         "active", is(true),
@@ -238,6 +243,7 @@ public class UsersIT extends ScimpleITSupport {
 
     patch("/Users/" + id, patchBody)
       .statusCode(200)
+      .header("Location", matchesRegex(".*/Users/" + id))
       .body(
         "active", is(false)
       );


### PR DESCRIPTION
The value of the location header returned from patch and update requests had the id of the resource duplicated in the URL, example `http://localhost:8080/Users/3/3` while correct is `http://localhost:8080/Users/3`.

This PR is fixing the location header generation:

- Patch and Update already happen on a path including the resource id no need to append the id again
- Create happens on for example `/User` so the id can be appended.
