### PR TITLE
Disable parallel testing for Quarkus tests

### DIFF
--- a/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusGroupsIT.java
+++ b/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusGroupsIT.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.quarkus;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.directory.scim.compliance.tests.GroupsIT;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.net.URI;
 
@@ -29,6 +30,7 @@ import java.net.URI;
  * Wraps GroupsIT in a Quarkus friendly runner.
  */
 @QuarkusIntegrationTest
+@Isolated
 public class QuarkusGroupsIT extends GroupsIT {
 
   @TestHTTPResource("/v2")

--- a/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusResourceTypesIT.java
+++ b/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusResourceTypesIT.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.quarkus;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.directory.scim.compliance.tests.ResourceTypesIT;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.net.URI;
 
@@ -29,6 +30,7 @@ import java.net.URI;
  * Wraps ResourceTypesIT in a Quarkus friendly runner.
  */
 @QuarkusIntegrationTest
+@Isolated
 public class QuarkusResourceTypesIT extends ResourceTypesIT {
 
   @TestHTTPResource("/v2")

--- a/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusSchemasIT.java
+++ b/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusSchemasIT.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.quarkus;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.directory.scim.compliance.tests.SchemasIT;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.net.URI;
 
@@ -29,6 +30,7 @@ import java.net.URI;
  * Wraps SchemasIT in a Quarkus friendly runner.
  */
 @QuarkusIntegrationTest
+@Isolated
 public class QuarkusSchemasIT extends SchemasIT {
 
   @TestHTTPResource("/v2")

--- a/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusServiceProviderConfigIT.java
+++ b/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusServiceProviderConfigIT.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.quarkus;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.directory.scim.compliance.tests.ServiceProviderConfigIT;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.net.URI;
 
@@ -29,6 +30,7 @@ import java.net.URI;
  * Wraps ServiceProviderConfigIT in a Quarkus friendly runner.
  */
 @QuarkusIntegrationTest
+@Isolated
 public class QuarkusServiceProviderConfigIT extends ServiceProviderConfigIT {
 
   @TestHTTPResource("/v2")

--- a/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusUsersIT.java
+++ b/scim-server-examples/scim-server-quarkus/src/test/java/org/apache/directory/scim/example/quarkus/QuarkusUsersIT.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.example.quarkus;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.apache.directory.scim.compliance.tests.UsersIT;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.net.URI;
 
@@ -29,6 +30,7 @@ import java.net.URI;
  * Wraps UsersIT in a Quarkus friendly runner.
  */
 @QuarkusIntegrationTest
+@Isolated
 public class QuarkusUsersIT extends UsersIT {
 
   @TestHTTPResource("/v2")


### PR DESCRIPTION
Per this thread, this is currently not supported
https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Parallel.20Testing.20with.20JUnit.205.3F

Running these small tests in parallel this way only shaves a couple of seconds off the overall build time,
Forking multiple JVMs might work, but overall that takes more resoruces than running the tests sequentially

Related to: https://github.com/quarkusio/quarkus/issues/42296
