### PR TITLE
Make test reports less verbose for passing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,7 @@
             <configuration>
               <!-- parent pom overrides the default, so we MUST set the jacoco argline directly -->
               <argLine>@{jacoco.argline}</argLine>
+              <enablePropertiesElement>false</enablePropertiesElement>
               <includes>
                 <include>**/Test*.java</include>
                 <include>**/*Test.java</include>
@@ -594,6 +595,7 @@
             <version>3.3.1</version>
             <configuration>
               <argLine>@{jacoco.it.argline}</argLine>
+              <enablePropertiesElement>false</enablePropertiesElement>
               <includes>
                 <include>**/*IT.java</include>
               </includes>


### PR DESCRIPTION
Surefire 3.3.1 adds a property `enablePropertiesElement` to allow for less verbose test output in passing tests
