### PR TITLE
PATCH add/remove/replace extensions using path to extension but not to exact attribute

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
@@ -147,34 +147,7 @@ public class DefaultPatchHandler implements PatchHandler {
           throw new IllegalArgumentException("Invalid attribute path found in patch request: " + attributeReference);
         }
 
-        // root extension object found, per RFC, the value of the patch must be a Map
-        if (!(patchOperation.getValue() instanceof Map)) {
-          throw new IllegalArgumentException("Invalid patch value for root of extension, expected map");
-        }
-
-        // loop through each attribute and update them
-        Map<String, ?> mapValue = (Map<String, ?>) patchOperation.getValue();
-        for (Map.Entry<String, ?> entry : mapValue.entrySet()) {
-          String attributeName = entry.getKey();
-          Attribute attribute = schema.getAttribute(attributeName);
-          checkMutability(attribute);
-
-          // recreate the valuePathExpression using each child attribute
-          ValuePathExpression extensionValuePathExpression = new ValuePathExpression(new AttributeReference(schema.getUrn(), attributeName));
-
-          // ensure the sourceAsMap contains the extensions object, create one if needed.
-          PatchOperation.Type op = patchOperation.getOperation();
-          if (op == PatchOperation.Type.ADD || op == PatchOperation.Type.REPLACE) {
-            sourceAsMap.computeIfAbsent(schema.getUrn(), k -> new HashMap<>());
-            List<String> schemas = (List<String>) sourceAsMap.get("schemas");
-            if (!schemas.contains(attributeName)) {
-              schemas.add(attributeName);
-            }
-          }
-
-          // now update the sourceAsMap
-          patchOperationHandler.applyExtensionValue(source, sourceAsMap, schema, attribute, extensionValuePathExpression, schema.getUrn(), entry.getValue());
-        }
+        patchOperationHandler.applyRootExtensionValue(source, sourceAsMap, schema, patchOperation.getValue());
       }
     } else {
       Schema schema = this.schemaRegistry.getSchema(source.getBaseUrn());
@@ -266,6 +239,28 @@ public class DefaultPatchHandler implements PatchHandler {
         }
       } else {
         this.applySingleValue(data, attribute, valuePathExpression.getAttributePath(), value);
+      }
+    }
+
+    default <T extends ScimResource> void applyRootExtensionValue(final T source, Map<String, Object> sourceAsMap, Schema schema, Object value) {
+
+      // root extension object found, per RFC, the value of the patch must be a Map
+      if (!(value instanceof Map)) {
+        throw new IllegalArgumentException("Invalid patch value for root of extension, expected map");
+      }
+
+      // loop through each attribute and update them
+      Map<String, ?> mapValue = (Map<String, ?>) value;
+      for (Map.Entry<String, ?> entry : mapValue.entrySet()) {
+        String attributeName = entry.getKey();
+        Attribute attribute = schema.getAttribute(attributeName);
+        checkMutability(attribute);
+
+        // recreate the valuePathExpression using each child attribute
+        ValuePathExpression extensionValuePathExpression = new ValuePathExpression(new AttributeReference(schema.getUrn(), attributeName));
+
+        // now update the sourceAsMap
+        applyExtensionValue(source, sourceAsMap, schema, attribute, extensionValuePathExpression, schema.getUrn(), entry.getValue());
       }
     }
 
@@ -370,6 +365,21 @@ public class DefaultPatchHandler implements PatchHandler {
   private static class ReplaceOperationHandler implements PatchOperationHandler {
 
     @Override
+    public <T extends ScimResource> void applyExtensionValue(T source, Map<String, Object> sourceAsMap, Schema schema, Attribute attribute, ValuePathExpression valuePathExpression, String urn, Object value) {
+
+      // add the extension URN
+      Collection<String> schemas = (Collection<String>) sourceAsMap.get("schemas");
+      schemas.add(urn);
+
+      // if the extension object does not yet exist, create it
+      if (!sourceAsMap.containsKey(urn)) {
+        sourceAsMap.put(urn, new HashMap<>());
+      }
+
+      PatchOperationHandler.super.applyExtensionValue(source, sourceAsMap, schema, attribute, valuePathExpression, urn, value);
+    }
+
+    @Override
     public void applySingleValue(Map<String, Object> sourceAsMap, Attribute attribute, AttributeReference attributeReference, Object value) {
       if (attributeReference.hasSubAttribute()) {
         Map<String, Object> parentValue = (Map<String, Object>) sourceAsMap.get(attributeReference.getAttributeName());
@@ -436,6 +446,22 @@ public class DefaultPatchHandler implements PatchHandler {
       } else {
         // call super (default method of interface)
         PatchOperationHandler.super.applyValue(source, sourceAsMap, schema, attribute, valuePathExpression, value);
+      }
+    }
+
+    @Override
+    public <T extends ScimResource> void applyRootExtensionValue(T source, Map<String, Object> sourceAsMap, Schema schema, Object value) {
+
+      // remove the whole extension if value is null
+      if (value == null) {
+        // remove the schema definition
+        Collection<String> schemas = (Collection<String>) sourceAsMap.get("schemas");
+        schemas.remove(schema.getUrn());
+
+        // remove the root extension object
+        sourceAsMap.remove(schema.getUrn());
+      } else {
+        throw new IllegalArgumentException("Unsupported remove operation, expected patch value to be null when removing full extension object.");
       }
     }
 

--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
@@ -132,10 +132,50 @@ public class DefaultPatchHandler implements PatchHandler {
     // if the attribute has a URN, assume it's an extension that URN does not match the baseUrn
     if (attributeReference.hasUrn() && !attributeReference.getUrn().equals(source.getBaseUrn())) {
       Schema schema = this.schemaRegistry.getSchema(attributeReference.getUrn());
-      Attribute attribute = schema.getAttribute(attributeReference.getAttributeName());
-      checkMutability(schema.getAttributeFromPath(attributeReference.getFullAttributeName()));
 
-      patchOperationHandler.applyExtensionValue(source, sourceAsMap, schema, attribute, valuePathExpression, attributeReference.getUrn(), patchOperation.getValue());
+      if (schema != null) {
+        Attribute attribute = schema.getAttribute(attributeReference.getAttributeName());
+        checkMutability(schema.getAttributeFromPath(attributeReference.getFullAttributeName()));
+
+        patchOperationHandler.applyExtensionValue(source, sourceAsMap, schema, attribute, valuePathExpression, attributeReference.getUrn(), patchOperation.getValue());
+      } else {
+        // If schema is null, it's either the root of an extension, or an invalid patch path
+        // It's not possible from the antlr parser to tell the diff between 'this:is:extension:urn' and 'this:is:extension:urn:attribute'
+        // Check if the fully qualified attribute is a valid schema
+        schema = this.schemaRegistry.getSchema(attributeReference.getFullyQualifiedAttributeName());
+        if (schema == null) {
+          throw new IllegalArgumentException("Invalid attribute path found in patch request: " + attributeReference);
+        }
+
+        // root extension object found, per RFC, the value of the patch must be a Map
+        if (!(patchOperation.getValue() instanceof Map)) {
+          throw new IllegalArgumentException("Invalid patch value for root of extension, expected map");
+        }
+
+        // loop through each attribute and update them
+        Map<String, ?> mapValue = (Map<String, ?>) patchOperation.getValue();
+        for (Map.Entry<String, ?> entry : mapValue.entrySet()) {
+          String attributeName = entry.getKey();
+          Attribute attribute = schema.getAttribute(attributeName);
+          checkMutability(attribute);
+
+          // recreate the valuePathExpression using each child attribute
+          ValuePathExpression extensionValuePathExpression = new ValuePathExpression(new AttributeReference(schema.getUrn(), attributeName));
+
+          // ensure the sourceAsMap contains the extensions object, create one if needed.
+          PatchOperation.Type op = patchOperation.getOperation();
+          if (op == PatchOperation.Type.ADD || op == PatchOperation.Type.REPLACE) {
+            sourceAsMap.computeIfAbsent(schema.getUrn(), k -> new HashMap<>());
+            List<String> schemas = (List<String>) sourceAsMap.get("schemas");
+            if (!schemas.contains(attributeName)) {
+              schemas.add(attributeName);
+            }
+          }
+
+          // now update the sourceAsMap
+          patchOperationHandler.applyExtensionValue(source, sourceAsMap, schema, attribute, extensionValuePathExpression, schema.getUrn(), entry.getValue());
+        }
+      }
     } else {
       Schema schema = this.schemaRegistry.getSchema(source.getBaseUrn());
       Attribute attribute = schema.getAttribute(attributeReference.getAttributeName());

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -64,7 +64,6 @@ public class PatchHandlerTest {
     enterpriseExtensionValue.put("costCenter", "New Cost Center");
     enterpriseExtensionValue.put("department", "New Department");
     PatchOperation op = patchOperation(REPLACE, enterpriseExtensionUrn, enterpriseExtensionValue);
-    // This throws an NPE because DefaultPatchHandler is treating the path as an exact path to a simple attribute and not a path to a complex attribute
     ScimUser updatedUser = patchHandler.apply(user(), List.of(op));
     EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
     assertThat(actual).isNotNull();
@@ -72,6 +71,13 @@ public class PatchHandlerTest {
     assertThat(actual.getDepartment()).isEqualTo("New Department");
   }
 
+  @Test
+  public void applyRemoveEntireEnterpriseExtension() {
+    String enterpriseExtensionUrn = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    PatchOperation op = patchOperation(REMOVE, enterpriseExtensionUrn, null);
+    ScimUser updatedUser = patchHandler.apply(user(), List.of(op));
+    assertThat(updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User")).isNull();
+  }
 
   @Test
   public void applyReplaceUserName()  {

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -19,16 +19,6 @@
 
 package org.apache.directory.scim.core.repository;
 
-import static java.util.Map.entry;
-import static org.apache.directory.scim.spec.patch.PatchOperation.Type.ADD;
-import static org.apache.directory.scim.spec.patch.PatchOperation.Type.REMOVE;
-import static org.apache.directory.scim.spec.patch.PatchOperation.Type.REPLACE;
-import static org.apache.directory.scim.test.assertj.ScimpleAssertions.scimAssertThat;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import lombok.SneakyThrows;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension;
@@ -45,6 +35,15 @@ import org.apache.directory.scim.spec.resources.PhoneNumber;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.junit.jupiter.api.Test;
+
+import static org.apache.directory.scim.spec.patch.PatchOperation.Type.*;
+import static java.util.Map.entry;
+import static org.apache.directory.scim.test.assertj.ScimpleAssertions.scimAssertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class PatchHandlerTest {
 

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.directory.scim.core.repository;
 
+import java.util.HashMap;
 import lombok.SneakyThrows;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension;
@@ -55,6 +56,22 @@ public class PatchHandlerTest {
     schemaRegistry.addSchema(ScimGroup.class, null);
     this.patchHandler = new DefaultPatchHandler(schemaRegistry);
   }
+
+  @Test
+  public void applyReplaceEntireEnterpriseExtension() {
+    String enterpriseExtensionUrn = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    Map<String, String> enterpriseExtensionValue = new HashMap<>();
+    enterpriseExtensionValue.put("costCenter", "New Cost Center");
+    enterpriseExtensionValue.put("department", "New Department");
+    PatchOperation op = patchOperation(REPLACE, enterpriseExtensionUrn, enterpriseExtensionValue);
+    // This throws an NPE because DefaultPatchHandler is treating the path as an exact path to a simple attribute and not a path to a complex attribute
+    ScimUser updatedUser = patchHandler.apply(user(), List.of(op));
+    EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
+    assertThat(actual).isNotNull();
+    assertThat(actual.getCostCenter()).isEqualTo("New Cost Center");
+    assertThat(actual.getDepartment()).isEqualTo("new Department");
+  }
+
 
   @Test
   public void applyReplaceUserName()  {

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -19,7 +19,16 @@
 
 package org.apache.directory.scim.core.repository;
 
-import java.util.HashMap;
+import static java.util.Map.entry;
+import static org.apache.directory.scim.spec.patch.PatchOperation.Type.ADD;
+import static org.apache.directory.scim.spec.patch.PatchOperation.Type.REMOVE;
+import static org.apache.directory.scim.spec.patch.PatchOperation.Type.REPLACE;
+import static org.apache.directory.scim.test.assertj.ScimpleAssertions.scimAssertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension;
@@ -37,15 +46,6 @@ import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.directory.scim.spec.patch.PatchOperation.Type.*;
-import static java.util.Map.entry;
-import static org.apache.directory.scim.test.assertj.ScimpleAssertions.scimAssertThat;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 public class PatchHandlerTest {
 
   DefaultPatchHandler patchHandler;
@@ -60,12 +60,13 @@ public class PatchHandlerTest {
   @Test
   public void applyReplaceEntireEnterpriseExtension() {
     String enterpriseExtensionUrn = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
-    Map<String, String> enterpriseExtensionValue = new HashMap<>();
-    enterpriseExtensionValue.put("costCenter", "New Cost Center");
-    enterpriseExtensionValue.put("department", "New Department");
+    Map<String, String> enterpriseExtensionValue = Map.ofEntries(
+            entry("costCenter", "New Cost Center"),
+            entry("department", "New Department")
+    );
     PatchOperation op = patchOperation(REPLACE, enterpriseExtensionUrn, enterpriseExtensionValue);
     ScimUser updatedUser = patchHandler.apply(user(), List.of(op));
-    EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
+    EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension(enterpriseExtensionUrn);
     assertThat(actual).isNotNull();
     assertThat(actual.getCostCenter()).isEqualTo("New Cost Center");
     assertThat(actual.getDepartment()).isEqualTo("New Department");
@@ -74,13 +75,13 @@ public class PatchHandlerTest {
   @Test
   public void applyReplaceEntireEnterpriseExtensionWithNullPath() {
     String enterpriseExtensionUrn = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
-    Map<String, String> enterpriseExtensionValue = Map.of(
-        "costCenter", "New Cost Center",
-        "department", "New Department"
+    Map<String, String> enterpriseExtensionValue = Map.ofEntries(
+        entry("costCenter", "New Cost Center"),
+        entry("department", "New Department")
     );
     PatchOperation op = patchOperation(REPLACE, null, Map.of(enterpriseExtensionUrn, enterpriseExtensionValue));
     ScimUser updatedUser = patchHandler.apply(user(), List.of(op));
-    EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
+    EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension(enterpriseExtensionUrn);
     assertThat(actual).isNotNull();
     assertThat(actual.getCostCenter()).isEqualTo("New Cost Center");
     assertThat(actual.getDepartment()).isEqualTo("New Department");
@@ -91,7 +92,7 @@ public class PatchHandlerTest {
     String enterpriseExtensionUrn = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
     PatchOperation op = patchOperation(REMOVE, enterpriseExtensionUrn, null);
     ScimUser updatedUser = patchHandler.apply(user(), List.of(op));
-    assertThat(updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User")).isNull();
+    assertThat(updatedUser.getExtension(enterpriseExtensionUrn)).isNull();
   }
 
   @Test

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -72,6 +72,21 @@ public class PatchHandlerTest {
   }
 
   @Test
+  public void applyReplaceEntireEnterpriseExtensionWithNullPath() {
+    String enterpriseExtensionUrn = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    Map<String, String> enterpriseExtensionValue = Map.of(
+        "costCenter", "New Cost Center",
+        "department", "New Department"
+    );
+    PatchOperation op = patchOperation(REPLACE, null, Map.of(enterpriseExtensionUrn, enterpriseExtensionValue));
+    ScimUser updatedUser = patchHandler.apply(user(), List.of(op));
+    EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
+    assertThat(actual).isNotNull();
+    assertThat(actual.getCostCenter()).isEqualTo("New Cost Center");
+    assertThat(actual.getDepartment()).isEqualTo("New Department");
+  }
+
+  @Test
   public void applyRemoveEntireEnterpriseExtension() {
     String enterpriseExtensionUrn = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
     PatchOperation op = patchOperation(REMOVE, enterpriseExtensionUrn, null);

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -69,7 +69,7 @@ public class PatchHandlerTest {
     EnterpriseExtension actual = (EnterpriseExtension) updatedUser.getExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
     assertThat(actual).isNotNull();
     assertThat(actual.getCostCenter()).isEqualTo("New Cost Center");
-    assertThat(actual.getDepartment()).isEqualTo("new Department");
+    assertThat(actual.getDepartment()).isEqualTo("New Department");
   }
 
 


### PR DESCRIPTION
When you attempt to replace an entire extension schema (using EnterpriseSchema as an example here), scimple throws a Null Pointer exception

```
java.lang.NullPointerException
	at org.apache.directory.scim.core.repository.DefaultPatchHandler.apply(DefaultPatchHandler.java:135)
	at org.apache.directory.scim.core.repository.DefaultPatchHandler.apply(DefaultPatchHandler.java:118)
	at org.apache.directory.scim.core.repository.PatchHandlerTest.applyReplaceEntireEnterpriseExtension(PatchHandlerTest.java:327)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
```

This is because it is not treating it as an entire resource replacement but an exact path 

![image](https://github.com/user-attachments/assets/58b134bc-668d-426a-99f8-90e89b7ce31d)
