### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,7 +57,7 @@ jobs:
         id: mvnBuild
         run: ./mvnw ${{ inputs.mvn }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Add PR Comment
         if: github.event.pull_request.number != ''

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -22,6 +22,7 @@
 <develocity
     xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <projectId>scimple</projectId>
   <server>
     <url>https://develocity.apache.org</url>
   </server>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -23,7 +23,7 @@
     xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
   <server>
-    <url>https://ge.apache.org</url>
+    <url>https://develocity.apache.org</url>
   </server>
   <buildScan>
     <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>


### PR DESCRIPTION
This PR migrates the SCIMple project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR sets a projectId for use by Develocity.
