### PR TITLE
GitHub Action output variables need to end with a new line

### DIFF
--- a/.mvn/develocity-custom-user-data.groovy
+++ b/.mvn/develocity-custom-user-data.groovy
@@ -52,6 +52,7 @@ if (isGitHubActions()) {
         << "buildscan_id=${id}"
         << '\n'
         << "buildscan_uri=${uri}"
+        << '\n'
     })
   })
 


### PR DESCRIPTION
If they don't end with a new line the next step's output may end up on the same line
