### PR TITLE
Exclude native dep used by Quarkus

### DIFF
--- a/scim-server-examples/scim-server-quarkus/pom.xml
+++ b/scim-server-examples/scim-server-quarkus/pom.xml
@@ -69,6 +69,15 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- brings in unused native dependency
+               It's not used in this example, and it causes issues
+               with Reproducible Builds and the maven-remote-resources-plugin -->
+          <groupId>com.aayushatharva.brotli4j</groupId>
+          <artifactId>brotli4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This causes the META-INF/DEPENDENCIES file to be generated with playform dependent output
(if build on mac you get one dependency, if built on linux you get another)

Since this example proejct is NOT building native binaries or using the "br" compression, this can be safely excluded.
