### PR TITLE
Use templates for GitHub Actions summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
               -Dexpression=project.version \
               help:evaluate \
               | tail -n 1)
+            echo "project-version=$PROJECT_VERSION"
             echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -85,6 +86,7 @@ jobs:
         id: nexus
         run: |
           export NEXUS_URL=$(awk '/^(stagingRepository.url)/ { gsub(/(^.+=|\\)/, ""); print $1 }' target/nexus-staging/staging/*.properties)
+          echo "nexus-url: $NEXUS_URL"
           echo "nexus-url=$NEXUS_URL" >> $GITHUB_OUTPUT
 
       - name: Upload to Dist to Subversion
@@ -130,62 +132,26 @@ jobs:
             --username "$SVN_USERNAME" \
             --password "$SVN_PASSWORD" \
             -m "Added \`${DIST_FILE_NAME}\` artifacts for release \`${PROJECT_VERSION}\`"
-          echo "svn-dist-url=${SVN_BASE_URL}/${PROJECT_VERSION}/${DIST_FILE_NAME}" >> $GITHUB_OUTPUT
+          export SVN_DIST_URL="${SVN_BASE_URL}/${PROJECT_VERSION}/${DIST_FILE_NAME}"
+          echo "svn-dist-url=${SVN_DIST_URL}"
+          echo "svn-dist-url=${SVN_DIST_URL}" >> $GITHUB_OUTPUT
 
       - name: Failure Summary
         if: failure()
         shell: bash
         run: |
-          cat << EOF >> $GITHUB_STEP_SUMMARY
-          Release of tag ${{ github.ref_name }} with POM version ${{ steps.version.outputs.project-version }} failed ❌
-          You may need to cleanup:
-          - The Nexus staging repository: https://repository.apache.org/#stagingRepositories
-          - The staged Source bundle: ${{ steps.svn.outputs.svn-dist-url }}
-          
-          To re-run the release, you will need to delete the tag and re-push it.
-          EOF
+          ./mvnw -N -Pci-templating resources:copy-resources \
+            -DgitRef=${{ github.ref_name }} \
+            -DnexusStagingUrl=${{ steps.nexus.outputs.nexus-url }} \
+            -DsvnDistUrl=${{ steps.svn.outputs.svn-dist-url }} \
+          cat ./target/release-failure-summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Success Summary
         shell: bash
         run: |
-          cat << EOF >> $GITHUB_STEP_SUMMARY
-          The release of tag ${{ github.ref_name }} with POM version ${{ steps.version.outputs.project-version }} has been staged ✅
-          
-          The next step is to check if the release is reproducible by running a Maven build locally
-          using against the source dist zip and the tag, for each run the command:
-          
-          ```bash
-          ./mvn clean verify artifact:compare \
-            -Dreference.repo=${{ steps.nexus.outputs.nexus-url }}
-          ```
-          
-          If that was successful, start the vote email thread, suggested email template:
-          
-          ```txt
-          Subject: [VOTE] Release Apache Directory ${{ env.PROJECT_NAME }} ${{ steps.version.outputs.project-version }}
-            
-          This is a call to vote in favor of releasing Apache Directory ${{ env.PROJECT_NAME }} version ${{ steps.version.outputs.project-version }}.
-          
-          We solved # issues:
-            <insert release notes or link to release notes> (see below for suggestion)
-          
-          Maven Staging repo: 
-            ${{ steps.nexus.outputs.nexus-url }}
-          
-          Dist Staging Repository:
-            ${{ steps.svn.outputs.svn-dist-url }}
-          
-          Guide to testing staged releases:
-            https://maven.apache.org/guides/development/guide-testing-releases.html
-            
-          Vote open for 72 hours.
-          
-          [ ] +1
-          [ ] +0
-          [ ] -1 (please include reasoning)
-          ```
-          
-          Changelog:
-      
-          EOF
+          ./mvnw -N -Pci-templating resources:copy-resources \
+            -DgitRef=${{ github.ref_name }} \
+            -DnexusStagingUrl=${{ steps.nexus.outputs.nexus-url }} \
+            -DsvnDistUrl=${{ steps.svn.outputs.svn-dist-url }} \
+          cat ./target/release-success-summary.md >> $GITHUB_STEP_SUMMARY
           cat ${{ steps.mvn.outputs.changelog-md }} >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -59,6 +59,7 @@ jobs:
               -Dexpression=project.version \
               help:evaluate \
               | tail -n 1)
+            echo "project-version=$PROJECT_VERSION"
             echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -82,10 +83,7 @@ jobs:
       - name: Success Summary
         shell: bash
         run: |
-          cat << EOF >> $GITHUB_STEP_SUMMARY
-          The SNAPSHOT build from \`${{ github.ref_name }}\` with POM version \[\`${{ steps.version.outputs.project-version }}\`\]\(https://repository.apache.org/#nexus-search;gav~org.apache.directory.scimple~~${{ steps.version.outputs.project-version }}~~\) has been deployed ✅
-          
-          Changes in this build since the last release:
-      
-          EOF
+          ./mvnw -N -Pci-templating resources:copy-resources \
+            -DgitRef=${{ github.ref_name }}
+          cat ./target/snapshot-success-summary.md >> $GITHUB_STEP_SUMMARY
           cat ${{ steps.mvn.outputs.changelog-md }} >> $GITHUB_STEP_SUMMARY

--- a/pom.xml
+++ b/pom.xml
@@ -1021,5 +1021,25 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>ci-templating</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/src/ci-templates</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/src/ci-templates/release-failure-summary.md
+++ b/src/ci-templates/release-failure-summary.md
@@ -1,0 +1,7 @@
+Release of tag `${gitRef}` with POM version `${project.version}` failed ❌
+
+You may need to clean up the following:
+- The [Nexus staging repository](https://repository.apache.org/#stagingRepositories) (empty if Maven build failed): ${nexusStagingUrl}
+- The staged Source bundle: ${svnDistUrl}
+
+To re-run the release, you will need to delete the tag and re-push it.

--- a/src/ci-templates/release-success-summary.md
+++ b/src/ci-templates/release-success-summary.md
@@ -1,0 +1,64 @@
+The release of tag `${gitRef}` with POM version `${project.version}` has been staged ✅
+
+The next step is to check if the release is reproducible by running a Maven build locally
+using against the source dist zip and the tag.
+
+For the source bundle you can run a command similar to:
+
+```bash
+# create a tmp dir
+cd $(mktemp -d)
+
+# Download the source bundle:
+curl -s "${nexusStagingUrl}/org/apache/directory/scimple/scimple/${project.version}/scimple-${project.version}-source-release.zip" -O
+
+# extract the source zip
+unzip scimple-${project.version}-source-release.zip
+cd scimple-${project.version}
+
+# rebuild the source bundle and verify
+./mvnw clean verify artifact:compare \
+  --threads=1 \
+  -Dreference.repo=${nexusStagingUrl}
+```
+
+From your SCIMple git repository build the `${gitRef}` tag run:
+```bash
+# If you haven't cloned the repo, run:
+# git clone ${project.scm.url}.git 
+# cd directory-scimple
+
+# checkout the tag
+git checkout ${gitRef}
+
+# rebuild the source bundle and verify
+./mvnw clean verify artifact:compare \
+  --threads=1 \
+  -Dreference.repo=${nexusStagingUrl}
+```
+
+If that was successful, start the vote email thread, suggested email template:
+
+```txt
+Subject: [VOTE] Release Apache Directory ${project.name} ${project.version}
+  
+This is a call to vote in favor of releasing Apache Directory ${project.name} version ${project.version}.
+
+We solved # issues:
+  <insert release notes or link to release notes> (see below for suggestion)
+
+Maven Staging Repository: 
+  ${nexusStagingUrl}
+
+Dist Staging Url:
+  ${svnDistUrl}
+
+Guide to testing staged releases:
+  https://maven.apache.org/guides/development/guide-testing-releases.html
+  
+Vote open for 72 hours.
+
+[ ] +1
+[ ] +0
+[ ] -1 (please include reasoning)
+```

--- a/src/ci-templates/snapshot-success-summary.md
+++ b/src/ci-templates/snapshot-success-summary.md
@@ -1,0 +1,3 @@
+The SNAPSHOT build from `${gitRef}` with POM version [`${project.version}`](https://repository.apache.org/#nexus-search;gav~org.apache.directory.scimple~~${project.version}~~) has been deployed ✅
+
+Changes in this build since the last release:

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Sets release version, creates tag, and pushes tag to 'origin'
+# ----------------------------------------------------------------------------
+script_name=$0
+function usage {
+    echo "usage: ${script_name} [release-version]"
+    echo "  Sets release version, creates tag, and pushes tag to 'origin'"
+    exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+fi
+
+version="${1}"
+tag="v${version}"
+echo "Updating version to: ${version}"
+./mvnw versions:set -DnewVersion=${version} -N
+
+git commit -am "[release] Setting version to ${version}"
+
+echo "Creating the tag: ${tag}"
+git tag --sign ${tag} -m "[release] ${version}"
+git push origin ${tag}


### PR DESCRIPTION
Simple templating using the Maven Resources Plugin

- Added debug information to CI builds
- Added basic release.sh, which calls `mvn versions:set`, creates a tag, and pushes it
