### PR TITLE
Make it easier to run the equivalent reproducible build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,7 @@
             <release>
               <github>
                 <previousTagName>${previous.tag}</previousTagName>
+                <token>not_used</token>
                 <changelog>
                   <links>true</links>
                   <skipMergeCommits>true</skipMergeCommits>

--- a/src/ci-templates/release-success-summary.md
+++ b/src/ci-templates/release-success-summary.md
@@ -18,7 +18,9 @@ cd scimple-${project.version}
 
 # rebuild the source bundle and verify
 ./mvnw clean verify artifact:compare \
+  -Papache-release \
   --threads=1 \
+  -Dgpg.skip \
   -Dreference.repo=${nexusStagingUrl}
 ```
 
@@ -33,7 +35,9 @@ git checkout ${gitRef}
 
 # rebuild the source bundle and verify
 ./mvnw clean verify artifact:compare \
+  -Papache-release \
   --threads=1 \
+  -Dgpg.skip \
   -Dreference.repo=${nexusStagingUrl}
 ```
 


### PR DESCRIPTION
- Update the build output instructions to include the apache-release profile
- Default the jreleaser github token to "not_used" (as that logic is not currently used by this build)
