### PR TITLE
Enable Develocity remote caching

### DIFF
--- a/.github/workflows/build-reproducible.yml
+++ b/.github/workflows/build-reproducible.yml
@@ -50,9 +50,10 @@ jobs:
           cache: '' # disabled
 
       - name: Running Maven
-        run: ./mvnw install  \
-          -Ddevelocity.cache.local.enabled=false \
-          -Ddevelocity.cache.remote.enabled=false
+        run: |
+          ./mvnw install  \
+            -Ddevelocity.cache.local.enabled=false \
+            -Ddevelocity.cache.remote.enabled=false
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 

--- a/.github/workflows/build-reproducible.yml
+++ b/.github/workflows/build-reproducible.yml
@@ -50,14 +50,18 @@ jobs:
           cache: '' # disabled
 
       - name: Running Maven
-        run: ./mvnw install
+        run: ./mvnw install  \
+          -Ddevelocity.cache.local.enabled=false \
+          -Ddevelocity.cache.remote.enabled=false
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 
       - name: Running Maven again to check reproducibility
-        run: ./mvnw clean verify artifact:compare
+        run: ./mvnw clean verify artifact:compare  \
+          -Ddevelocity.cache.local.enabled=false \
+          -Ddevelocity.cache.remote.enabled=false
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 
       - name: Upload Build Info
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/.github/workflows/build-reproducible.yml
+++ b/.github/workflows/build-reproducible.yml
@@ -58,9 +58,10 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 
       - name: Running Maven again to check reproducibility
-        run: ./mvnw clean verify artifact:compare  \
-          -Ddevelocity.cache.local.enabled=false \
-          -Ddevelocity.cache.remote.enabled=false
+        run: |
+          ./mvnw clean verify artifact:compare  \
+            -Ddevelocity.cache.local.enabled=false \
+            -Ddevelocity.cache.remote.enabled=false
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
     uses: ./.github/workflows/maven.yml
     with:
-      mvn: verify -Pci
+      mvn: clean verify -Pci
       name: "Maven Verify (with Java ${{ matrix.java }}-zulu)"
       jobs_path: "build (${{ matrix.java }}) / maven"
       java-version: ${{ matrix.java }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,7 +62,7 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Maven Build
-        run: ./mvnw verify pmd:aggregate-pmd -Pci  \
+        run: ./mvnw verify pmd:aggregate-pmd -Pci \
           -Ddevelocity.cache.local.enabled=false \
           -Ddevelocity.cache.remote.enabled=false
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,7 +62,9 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Maven Build
-        run: ./mvnw verify pmd:aggregate-pmd -Pci
+        run: ./mvnw verify pmd:aggregate-pmd -Pci  \
+          -Ddevelocity.cache.local.enabled=false \
+          -Ddevelocity.cache.remote.enabled=false
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f #v3.28.18

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,9 +62,10 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Maven Build
-        run: ./mvnw verify pmd:aggregate-pmd -Pci \
-          -Ddevelocity.cache.local.enabled=false \
-          -Ddevelocity.cache.remote.enabled=false
+        run: |
+          ./mvnw verify pmd:aggregate-pmd -Pci \
+            -Ddevelocity.cache.local.enabled=false \
+            -Ddevelocity.cache.remote.enabled=false
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f #v3.28.18

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,7 +57,7 @@ jobs:
         id: mvnBuild
         run: ./mvnw ${{ inputs.mvn }}
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 
       - name: Add PR Comment
         if: github.event.pull_request.number != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             echo "project-version=$PROJECT_VERSION"
             echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 
       - name: Maven Release Build
         id: mvn
@@ -79,7 +79,7 @@ jobs:
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PW }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Capture Nexus Staging URL

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -62,7 +62,7 @@ jobs:
             echo "project-version=$PROJECT_VERSION"
             echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
 
       - name: Maven Snapshot Build
         id: mvn
@@ -77,7 +77,7 @@ jobs:
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PW }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DIRECTORY_DEVELOCITY_ACCESS_KEY }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Success Summary

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -40,7 +40,8 @@
       <enabled>#{isFalse(env['GITHUB_ACTIONS'])}</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
+      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS'])}</storeEnabled>
     </remote>
   </buildCache>
 </develocity>


### PR DESCRIPTION
A few notes:
* The `DIRECTORY_DEVELOCITY_ACCESS_KEY` is an access key specific to Apache Directory. No other projects can access it. For now, only `apache/directory-scimple` can access it, but this can be extended to other Directory projects.
* I added clean to the CI build job as cache entries are only stored when the [clean lifecycle is invoked](By default, outputs are stored in the Build Cache if it is enabled and the build includes the clean lifecycle phase)
* I disabled caching for:
    * CodeQL workflows - These break when [caching is enabled](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/no-source-code-seen-during-build#:~:text=Cached%20components%20not%20detected)
    * Reproducible builds - I _think_ this makes sense for this type of workflow