### PR TITLE
Disable remote cache storing for builds originating from forks

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -41,7 +41,7 @@
     </local>
     <remote>
       <enabled>true</enabled>
-      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS'])}</storeEnabled>
+      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['DEVELOCITY_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>
 </develocity>


### PR DESCRIPTION
This will prevent build cache errors from builds attempting to write from forked workflows