### PR TITLE
Correcting ENV var name in CI build

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -41,7 +41,7 @@
     </local>
     <remote>
       <enabled>true</enabled>
-      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['DIRECTORY_DEVELOCITY_ACCESS_KEY'])}</storeEnabled>
+      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['DEVELOCITY_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>
 </develocity>


### PR DESCRIPTION
From 13a96f103ee62f6e209075a036133fe821fd650b, the secret name is DIRECTORY_DEVELOCITY_ACCESS_KEY, but the env var is still DEVELOCITY_ACCESS_KEY
