### PR TITLE
fix "displayName" and some other attributes in "attributes" / "excludedAttributes" not working in GET /Groups

### DIFF
--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/AttributeUtil.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/AttributeUtil.java
@@ -26,9 +26,7 @@ import org.apache.directory.scim.server.exception.AttributeDoesNotExistException
 import org.apache.directory.scim.server.exception.AttributeException;
 import org.apache.directory.scim.spec.filter.attribute.AttributeReference;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.apache.directory.scim.spec.resources.ScimResource;
-import org.apache.directory.scim.spec.resources.ScimUser;
 import org.apache.directory.scim.spec.schema.AttributeContainer;
 import org.apache.directory.scim.spec.schema.Schema;
 import org.apache.directory.scim.spec.schema.Schema.Attribute;
@@ -99,7 +97,7 @@ class AttributeUtil {
       Schema schema = schemaRegistry.getBaseSchemaOfResourceType(resourceType);
 
       // return always and specified attributes, exclude never
-      Set<Attribute> attributesToKeep = resolveAttributeReferences(attributes, true);
+      Set<Attribute> attributesToKeep = resolveAttributeReferences(attributes, true, schema);
       Set<String> extensionsToRemove = new HashSet<>();
       removeAttributesOfType(copy, schema, Returned.DEFAULT, attributesToKeep);
       removeAttributesOfType(copy, schema, Returned.REQUEST, attributesToKeep);
@@ -146,7 +144,7 @@ class AttributeUtil {
       Schema schema = schemaRegistry.getBaseSchemaOfResourceType(resourceType);
 
       // return always and default, exclude never and specified attributes
-      Set<Attribute> attributesToRemove = resolveAttributeReferences(excludedAttributes, false);
+      Set<Attribute> attributesToRemove = resolveAttributeReferences(excludedAttributes, false, schema);
       removeAttributesOfType(copy, schema, Returned.REQUEST);
       removeAttributesOfType(copy, schema, Returned.NEVER);
       removeAttributes(copy, schema, attributesToRemove);
@@ -259,11 +257,11 @@ class AttributeUtil {
     return attributeReferences;
   }
 
-  private Set<Attribute> resolveAttributeReferences(Set<AttributeReference> attributeReferences, boolean includeAttributeChain) throws AttributeDoesNotExistException {
+  private Set<Attribute> resolveAttributeReferences(Set<AttributeReference> attributeReferences, boolean includeAttributeChain, Schema coreSchema) throws AttributeDoesNotExistException {
     Set<Attribute> attributes = new HashSet<>();
 
     for (AttributeReference attributeReference : attributeReferences) {
-      Set<Attribute> findAttributes = findAttribute(attributeReference, includeAttributeChain);
+      Set<Attribute> findAttributes = findAttribute(attributeReference, includeAttributeChain, coreSchema);
       if (!findAttributes.isEmpty()) {
         attributes.addAll(findAttributes);
       }
@@ -272,37 +270,20 @@ class AttributeUtil {
     return attributes;
   }
 
-  private Set<Attribute> findAttribute(AttributeReference attributeReference, boolean includeAttributeChain) throws AttributeDoesNotExistException {
+  private Set<Attribute> findAttribute(AttributeReference attributeReference, boolean includeAttributeChain, Schema coreSchema) throws AttributeDoesNotExistException {
+    Schema schema = coreSchema;
     String schemaUrn = attributeReference.getUrn();
-    Schema schema = null;
-    Set<Attribute> attributes;
-    
     if (!StringUtils.isEmpty(schemaUrn)) {
       schema = schemaRegistry.getSchema(schemaUrn);
-
-      attributes = findAttributeInSchema(schema, attributeReference, includeAttributeChain);
-      if (attributes.isEmpty()) {
-        log.error("Attribute " + attributeReference.getFullyQualifiedAttributeName() + "not found in schema " + schemaUrn);
-        throw new AttributeDoesNotExistException(attributeReference.getFullyQualifiedAttributeName());
-      }
-      return attributes;
     }
 
-    // Handle unqualified attributes, look in the core schemas
-    schema = schemaRegistry.getSchema(ScimUser.SCHEMA_URI);
+    Set<Attribute> attributes;
     attributes = findAttributeInSchema(schema, attributeReference, includeAttributeChain);
-    if (!attributes.isEmpty()) {
-      return attributes;
+    if (attributes.isEmpty()) {
+      log.error("Attribute {} not found in schema {}", attributeReference.getFullyQualifiedAttributeName(), schemaUrn);
+      throw new AttributeDoesNotExistException(attributeReference.getFullyQualifiedAttributeName());
     }
-
-    schema = schemaRegistry.getSchema(ScimGroup.SCHEMA_URI);
-    attributes = findAttributeInSchema(schema, attributeReference, includeAttributeChain);
-    if (!attributes.isEmpty()) {
-      return attributes;
-    }
-
-    log.error("Attribute " + attributeReference.getFullyQualifiedAttributeName() + "not found in any schema.");
-    throw new AttributeDoesNotExistException(attributeReference.getFullyQualifiedAttributeName());
+    return attributes;
   }
 
   private Set<Attribute> findAttributeInSchema(Schema schema, AttributeReference attributeReference, boolean includeAttributeChain) {

--- a/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
@@ -6,7 +6,7 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-
+ 
 * http://www.apache.org/licenses/LICENSE-2.0
 
 * Unless required by applicable law or agreed to in writing,
@@ -75,7 +75,7 @@ public class AttributeUtilTest {
   @Test
   public void testBaseResource() throws Exception {
     ScimUser resource = getScimUser();
-
+    
     debugJson(resource);
 
     resource = attributeUtil.setAttributesForDisplay(resource);
@@ -84,30 +84,30 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getId()).isNotNull();
     Assertions.assertThat(resource.getPassword()).isNull();
-
+    
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-
+    
     Assertions.assertThat(extension.getCostCenter()).isNotNull();
-
+    
     ExampleObjectExtension exampleObjectExtension = resource.getExtension(ExampleObjectExtension.class);
-
+    
     Assertions.assertThat(exampleObjectExtension.getValueAlways()).isNotNull();
     Assertions.assertThat(exampleObjectExtension.getValueDefault()).isNotNull();
     Assertions.assertThat(exampleObjectExtension.getValueRequest()).isNull();
     Assertions.assertThat(exampleObjectExtension.getValueNever()).isNull();
   }
-
+  
   @Test
   public void testIncludeAttributes() throws Exception {
     ScimUser resource = getScimUser();
-
+    
     debugJson(resource);
-
+    
     Set<AttributeReference> attributes = new HashSet<>();
     attributes.add(new AttributeReference("userName"));
     attributes.add(new AttributeReference("addresses.streetAddress"));
     resource = attributeUtil.setAttributesForDisplay(resource, attributes);
-
+    
     debugJson(resource);
 
     Assertions.assertThat(resource.getUserName()).isNotNull();
@@ -115,28 +115,28 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getActive()).isNull();
-
+    
     Assertions.assertThat(resource.getAddresses().get(0).getCountry()).isNull();
     Assertions.assertThat(resource.getAddresses().get(0).getStreetAddress()).isNotNull();
 
-
+    
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-
+    
     Assertions.assertThat(extension).as("%s should have been removed from extensions", EnterpriseExtension.URN).isNull();
   }
-
+  
   @Test
   public void testIncludeFullAttributes() throws Exception {
     ScimUser resource = getScimUser();
-
+    
     debugJson(resource);
-
+    
     Set<AttributeReference> attributes = new HashSet<>();
     attributes.add(new AttributeReference("userName"));
     attributes.add(new AttributeReference("name"));
     attributes.add(new AttributeReference("addresses"));
     resource = attributeUtil.setAttributesForDisplay(resource, attributes);
-
+    
     debugJson(resource);
 
     Assertions.assertThat(resource.getUserName()).isNotNull();
@@ -144,29 +144,29 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getActive()).isNull();
-
+    
     Assertions.assertThat(resource.getAddresses().get(0).getCountry()).isNotNull();
     Assertions.assertThat(resource.getAddresses().get(0).getStreetAddress()).isNotNull();
     Assertions.assertThat(resource.getAddresses().get(0).getCountry()).isNotNull();
 
-
+    
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
 
     Assertions.assertThat(extension).as("%s should have been removed from extensions", EnterpriseExtension.URN).isNull();
   }
-
+  
   @Test
   public void testIncludeAttributesWithExtension() throws Exception {
     ScimUser resource = getScimUser();
-
+    
     debugJson(resource);
-
+    
     Set<AttributeReference> attributeSet = new HashSet<>();
     attributeSet.add(new AttributeReference("userName"));
     attributeSet.add(new AttributeReference(EnterpriseExtension.URN + ":costCenter"));
-
+    
     resource = attributeUtil.setAttributesForDisplay(resource, attributeSet);
-
+    
     debugJson(resource);
 
     Assertions.assertThat(resource.getUserName()).isNotNull();
@@ -174,27 +174,27 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getActive()).isNull();
-
+    
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-
+    
     Assertions.assertThat(extension.getCostCenter()).isNotNull();
     Assertions.assertThat(extension.getDepartment()).isNull();
 
   }
-
+  
   @Test
   public void testExcludeAttributes() throws Exception {
     ScimUser resource = getScimUser();
-
+    
     debugJson(resource);
 
     Set<AttributeReference> attributeSet = new HashSet<>();
     attributeSet.add(new AttributeReference("userName"));
     attributeSet.add(new AttributeReference("addresses"));
     attributeSet.add(new AttributeReference("name"));
-
+    
     resource = attributeUtil.setExcludedAttributesForDisplay(resource, attributeSet);
-
+    
     debugJson(resource);
 
     Assertions.assertThat(resource.getId()).isNotNull();
@@ -205,27 +205,27 @@ public class AttributeUtilTest {
     Assertions.assertThat(resource.getName()).isNull();
 
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-
+    
     Assertions.assertThat(extension.getCostCenter()).isNotNull();
   }
-
+  
   @Test
   public void testExcludeAttributesWithExtensions() throws Exception {
     ScimUser resource = getScimUser();
-
+    
     Set<AttributeReference> attributeSet = new HashSet<>();
     attributeSet.add(new AttributeReference("userName"));
     attributeSet.add(new AttributeReference(EnterpriseExtension.URN + ":costCenter"));
-
+    
     resource = attributeUtil.setExcludedAttributesForDisplay(resource, attributeSet);
-
+    
     Assertions.assertThat(resource.getId()).isNotNull();
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getUserName()).isNull();
     Assertions.assertThat(resource.getActive()).isNotNull();
 
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-
+    
     Assertions.assertThat(extension.getCostCenter()).isNull();
     Assertions.assertThat(extension.getDepartment()).isNotNull();
   }
@@ -279,7 +279,7 @@ public class AttributeUtilTest {
     objectMapper.writeValue(sw, resource);
     LOG.debug(sw.toString());
   }
-
+  
   private ScimUser getScimUser() throws PhoneNumberParseException {
     ScimUser user = new ScimUser();
 
@@ -333,9 +333,9 @@ public class AttributeUtilTest {
     user.setAddresses(addresses);
 
     List<PhoneNumber> phoneNumbers = new ArrayList<>();
-
+    
     LocalPhoneNumberBuilder lpnb = new LocalPhoneNumberBuilder();
-
+    
     PhoneNumber phoneNumber = lpnb.areaCode("123").countryCode("1").subscriberNumber("456-7890").build();
     phoneNumber.setDisplay("123-456-7890");
     phoneNumber.setPrimary(true);
@@ -362,9 +362,9 @@ public class AttributeUtilTest {
     manager.setValue("0987654321");
     enterpriseEntension.setManager(manager);
     enterpriseEntension.setOrganization("ORG-X");
-
+    
     user.addExtension(enterpriseEntension);
-
+    
     ExampleObjectExtension exampleObjectExtension = new ExampleObjectExtension();
     exampleObjectExtension.setValueAlways("always");
     exampleObjectExtension.setValueDefault("default");
@@ -374,9 +374,9 @@ public class AttributeUtilTest {
     valueComplex.setDisplayName("ValueComplex");
     valueComplex.setValue("Value");
     exampleObjectExtension.setValueComplex(valueComplex);
-
+    
     user.addExtension(exampleObjectExtension);
-
+    
     return user;
   }
 

--- a/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/rest/AttributeUtilTest.java
@@ -6,7 +6,7 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
- 
+
 * http://www.apache.org/licenses/LICENSE-2.0
 
 * Unless required by applicable law or agreed to in writing,
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.directory.scim.core.json.ObjectMapperFactory;
+import org.apache.directory.scim.spec.resources.GroupMembership;
+import org.apache.directory.scim.spec.resources.ScimGroup;
+import org.apache.directory.scim.spec.schema.Meta;
 import org.apache.directory.scim.test.stub.ExampleObjectExtension;
 import org.apache.directory.scim.test.stub.ExampleObjectExtension.ComplexObject;
 import org.apache.directory.scim.spec.extension.EnterpriseExtension;
@@ -34,18 +37,16 @@ import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.PhoneNumber;
 import org.apache.directory.scim.spec.resources.PhoneNumber.LocalPhoneNumberBuilder;
 import org.apache.directory.scim.spec.resources.ScimUser;
-import org.apache.directory.scim.spec.schema.Schema;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
-import org.apache.directory.scim.spec.schema.Schemas;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -66,6 +67,7 @@ public class AttributeUtilTest {
   public void setup() {
     schemaRegistry = new SchemaRegistry();
     schemaRegistry.addSchema(ScimUser.class, List.of(EnterpriseExtension.class, ExampleObjectExtension.class));
+    schemaRegistry.addSchema(ScimGroup.class, List.of());
 
     attributeUtil = new AttributeUtil(schemaRegistry);
   }
@@ -73,7 +75,7 @@ public class AttributeUtilTest {
   @Test
   public void testBaseResource() throws Exception {
     ScimUser resource = getScimUser();
-    
+
     debugJson(resource);
 
     resource = attributeUtil.setAttributesForDisplay(resource);
@@ -82,30 +84,30 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getId()).isNotNull();
     Assertions.assertThat(resource.getPassword()).isNull();
-    
+
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-    
+
     Assertions.assertThat(extension.getCostCenter()).isNotNull();
-    
+
     ExampleObjectExtension exampleObjectExtension = resource.getExtension(ExampleObjectExtension.class);
-    
+
     Assertions.assertThat(exampleObjectExtension.getValueAlways()).isNotNull();
     Assertions.assertThat(exampleObjectExtension.getValueDefault()).isNotNull();
     Assertions.assertThat(exampleObjectExtension.getValueRequest()).isNull();
     Assertions.assertThat(exampleObjectExtension.getValueNever()).isNull();
   }
-  
+
   @Test
   public void testIncludeAttributes() throws Exception {
     ScimUser resource = getScimUser();
-    
+
     debugJson(resource);
-    
+
     Set<AttributeReference> attributes = new HashSet<>();
     attributes.add(new AttributeReference("userName"));
     attributes.add(new AttributeReference("addresses.streetAddress"));
     resource = attributeUtil.setAttributesForDisplay(resource, attributes);
-    
+
     debugJson(resource);
 
     Assertions.assertThat(resource.getUserName()).isNotNull();
@@ -113,28 +115,28 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getActive()).isNull();
-    
+
     Assertions.assertThat(resource.getAddresses().get(0).getCountry()).isNull();
     Assertions.assertThat(resource.getAddresses().get(0).getStreetAddress()).isNotNull();
 
-    
+
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-    
+
     Assertions.assertThat(extension).as("%s should have been removed from extensions", EnterpriseExtension.URN).isNull();
   }
-  
+
   @Test
   public void testIncludeFullAttributes() throws Exception {
     ScimUser resource = getScimUser();
-    
+
     debugJson(resource);
-    
+
     Set<AttributeReference> attributes = new HashSet<>();
     attributes.add(new AttributeReference("userName"));
     attributes.add(new AttributeReference("name"));
     attributes.add(new AttributeReference("addresses"));
     resource = attributeUtil.setAttributesForDisplay(resource, attributes);
-    
+
     debugJson(resource);
 
     Assertions.assertThat(resource.getUserName()).isNotNull();
@@ -142,29 +144,29 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getActive()).isNull();
-    
+
     Assertions.assertThat(resource.getAddresses().get(0).getCountry()).isNotNull();
     Assertions.assertThat(resource.getAddresses().get(0).getStreetAddress()).isNotNull();
     Assertions.assertThat(resource.getAddresses().get(0).getCountry()).isNotNull();
 
-    
+
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
 
     Assertions.assertThat(extension).as("%s should have been removed from extensions", EnterpriseExtension.URN).isNull();
   }
-  
+
   @Test
   public void testIncludeAttributesWithExtension() throws Exception {
     ScimUser resource = getScimUser();
-    
+
     debugJson(resource);
-    
+
     Set<AttributeReference> attributeSet = new HashSet<>();
     attributeSet.add(new AttributeReference("userName"));
     attributeSet.add(new AttributeReference(EnterpriseExtension.URN + ":costCenter"));
-    
+
     resource = attributeUtil.setAttributesForDisplay(resource, attributeSet);
-    
+
     debugJson(resource);
 
     Assertions.assertThat(resource.getUserName()).isNotNull();
@@ -172,27 +174,27 @@ public class AttributeUtilTest {
 
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getActive()).isNull();
-    
+
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-    
+
     Assertions.assertThat(extension.getCostCenter()).isNotNull();
     Assertions.assertThat(extension.getDepartment()).isNull();
 
   }
-  
+
   @Test
   public void testExcludeAttributes() throws Exception {
     ScimUser resource = getScimUser();
-    
+
     debugJson(resource);
 
     Set<AttributeReference> attributeSet = new HashSet<>();
     attributeSet.add(new AttributeReference("userName"));
     attributeSet.add(new AttributeReference("addresses"));
     attributeSet.add(new AttributeReference("name"));
-    
+
     resource = attributeUtil.setExcludedAttributesForDisplay(resource, attributeSet);
-    
+
     debugJson(resource);
 
     Assertions.assertThat(resource.getId()).isNotNull();
@@ -203,29 +205,73 @@ public class AttributeUtilTest {
     Assertions.assertThat(resource.getName()).isNull();
 
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-    
+
     Assertions.assertThat(extension.getCostCenter()).isNotNull();
   }
-  
+
   @Test
   public void testExcludeAttributesWithExtensions() throws Exception {
     ScimUser resource = getScimUser();
-    
+
     Set<AttributeReference> attributeSet = new HashSet<>();
     attributeSet.add(new AttributeReference("userName"));
     attributeSet.add(new AttributeReference(EnterpriseExtension.URN + ":costCenter"));
-    
+
     resource = attributeUtil.setExcludedAttributesForDisplay(resource, attributeSet);
-    
+
     Assertions.assertThat(resource.getId()).isNotNull();
     Assertions.assertThat(resource.getPassword()).isNull();
     Assertions.assertThat(resource.getUserName()).isNull();
     Assertions.assertThat(resource.getActive()).isNotNull();
 
     EnterpriseExtension extension = resource.getExtension(EnterpriseExtension.class);
-    
+
     Assertions.assertThat(extension.getCostCenter()).isNull();
     Assertions.assertThat(extension.getDepartment()).isNotNull();
+  }
+
+  @Test
+  void testGroupAttributes() throws Exception {
+    ScimGroup group = createScimGroup();
+
+    Set<AttributeReference> attributeSet = new HashSet<>();
+    attributeSet.add(new AttributeReference("displayName"));
+    attributeSet.add(new AttributeReference("meta.location"));
+    attributeSet.add(new AttributeReference(ScimGroup.SCHEMA_URI + ":externalId"));
+
+    group = attributeUtil.setAttributesForDisplay(group, attributeSet);
+
+    Assertions.assertThat(group.getId()).isNotNull();
+    Assertions.assertThat(group.getDisplayName()).isNotNull();
+    Assertions.assertThat(group.getExternalId()).isNotNull();
+    Assertions.assertThat(group.getMembers()).isNull();
+    Meta meta = group.getMeta();
+    Assertions.assertThat(meta).isNotNull();
+    Assertions.assertThat(meta.getLocation()).isNotNull();
+    Assertions.assertThat(meta.getCreated()).isNull();
+    Assertions.assertThat(meta.getLastModified()).isNull();
+  }
+
+  @Test
+  void testExcludedGroupAttributes() throws Exception {
+    ScimGroup group = createScimGroup();
+
+    Set<AttributeReference> excludedAttributeSet = new HashSet<>();
+    excludedAttributeSet.add(new AttributeReference("displayName"));
+    excludedAttributeSet.add(new AttributeReference("meta.location"));
+    excludedAttributeSet.add(new AttributeReference(ScimGroup.SCHEMA_URI + ":externalId"));
+
+    group = attributeUtil.setExcludedAttributesForDisplay(group, excludedAttributeSet);
+
+    Assertions.assertThat(group.getId()).isNotNull();
+    Assertions.assertThat(group.getDisplayName()).isNull();
+    Assertions.assertThat(group.getExternalId()).isNull();
+    Assertions.assertThat(group.getMembers()).isNotNull();
+    Meta meta = group.getMeta();
+    Assertions.assertThat(meta).isNotNull();
+    Assertions.assertThat(meta.getLocation()).isNull();
+    Assertions.assertThat(meta.getCreated()).isNotNull();
+    Assertions.assertThat(meta.getLastModified()).isNotNull();
   }
 
   private void debugJson(Object resource) throws JsonGenerationException, JsonMappingException, IOException {
@@ -233,7 +279,7 @@ public class AttributeUtilTest {
     objectMapper.writeValue(sw, resource);
     LOG.debug(sw.toString());
   }
-  
+
   private ScimUser getScimUser() throws PhoneNumberParseException {
     ScimUser user = new ScimUser();
 
@@ -287,9 +333,9 @@ public class AttributeUtilTest {
     user.setAddresses(addresses);
 
     List<PhoneNumber> phoneNumbers = new ArrayList<>();
-    
+
     LocalPhoneNumberBuilder lpnb = new LocalPhoneNumberBuilder();
-    
+
     PhoneNumber phoneNumber = lpnb.areaCode("123").countryCode("1").subscriberNumber("456-7890").build();
     phoneNumber.setDisplay("123-456-7890");
     phoneNumber.setPrimary(true);
@@ -316,9 +362,9 @@ public class AttributeUtilTest {
     manager.setValue("0987654321");
     enterpriseEntension.setManager(manager);
     enterpriseEntension.setOrganization("ORG-X");
-    
+
     user.addExtension(enterpriseEntension);
-    
+
     ExampleObjectExtension exampleObjectExtension = new ExampleObjectExtension();
     exampleObjectExtension.setValueAlways("always");
     exampleObjectExtension.setValueDefault("default");
@@ -328,10 +374,36 @@ public class AttributeUtilTest {
     valueComplex.setDisplayName("ValueComplex");
     valueComplex.setValue("Value");
     exampleObjectExtension.setValueComplex(valueComplex);
-    
+
     user.addExtension(exampleObjectExtension);
-    
+
     return user;
   }
 
+  private ScimGroup createScimGroup() {
+    ScimGroup group = new ScimGroup();
+    group.setId("g1");
+    group.setDisplayName("Group 1");
+    group.setExternalId("eg1");
+    GroupMembership member1 = new GroupMembership();
+    member1.setValue("u1");
+    member1.setDisplay("User 1");
+    member1.setType("User");
+    GroupMembership member2 = new GroupMembership();
+    member2.setValue("u2");
+    member2.setDisplay("User 2");
+    member2.setType("User");
+    GroupMembership member3 = new GroupMembership();
+    member3.setValue("g2");
+    member3.setDisplay("Group 2");
+    member3.setType("Group");
+    group.setMembers(new ArrayList<>(Arrays.asList(member1, member2, member3)));
+    Meta meta = new Meta();
+    meta.setResourceType("Group");
+    meta.setCreated(LocalDateTime.now());
+    meta.setLastModified(LocalDateTime.now());
+    meta.setLocation("https://example.com/Groups/g1");
+    group.setMeta(meta);
+    return group;
+  }
 }


### PR DESCRIPTION
Resolves #887 

Now the core schema resolved from resource type will be passed to findAttribute.