### PR TITLE
Add convenice method to add schema without extensions

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/schema/SchemaRegistry.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/schema/SchemaRegistry.java
@@ -71,9 +71,13 @@ public class SchemaRegistry implements Serializable {
     return schemaMap.get(schemaUrn);
   }
 
-  private void addSchema(Schema schema) {
+  private void addSchemaToRegistry(Schema schema) {
     log.debug("Adding schema " + schema.getId() + " into the registry");
     schemaMap.put(schema.getId(), schema);
+  }
+
+  public <T extends ScimResource> void addSchema(Class<T> clazz) {
+    this.addSchema(clazz, List.of());
   }
 
   public <T extends ScimResource> void addSchema(Class<T> clazz, List<Class<? extends ScimExtension>> extensionList) {
@@ -88,7 +92,7 @@ public class SchemaRegistry implements Serializable {
     String schemaUrn = scimResourceType.schema();
     String endpoint = scimResourceType.endpoint();
 
-    addSchema(Schemas.schemaFor(clazz));
+    addSchemaToRegistry(Schemas.schemaFor(clazz));
     addScimResourceSchemaUrn(schemaUrn, clazz);
     addScimResourceEndPoint(endpoint, clazz);
     addResourceType(resourceType);
@@ -96,7 +100,7 @@ public class SchemaRegistry implements Serializable {
     if (extensionList != null) {
       for (Class<? extends ScimExtension> scimExtension : extensionList) {
         log.debug("Calling addSchema on an extension: " + scimExtension);
-        addSchema(Schemas.schemaForExtension(scimExtension));
+        addSchemaToRegistry(Schemas.schemaForExtension(scimExtension));
         log.debug("Registering a extension of type: " + scimExtension);
         addExtension(clazz, scimExtension);
       }

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/PatchHandlerTest.java
@@ -51,7 +51,7 @@ public class PatchHandlerTest {
   public PatchHandlerTest() {
     SchemaRegistry schemaRegistry = new SchemaRegistry();
     schemaRegistry.addSchema(ScimUser.class, List.of(EnterpriseExtension.class));
-    schemaRegistry.addSchema(ScimGroup.class, null);
+    schemaRegistry.addSchema(ScimGroup.class);
     this.patchHandler = new DefaultPatchHandler(schemaRegistry);
   }
 

--- a/scim-core/src/test/java/org/apache/directory/scim/core/schema/SchemaRegistryTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/schema/SchemaRegistryTest.java
@@ -55,9 +55,10 @@ public class SchemaRegistryTest {
     groupType.setSchemaUrn(ScimGroup.SCHEMA_URI);
     groupType.setName(ScimGroup.RESOURCE_NAME);
     groupType.setDescription("Top level ScimGroup");
+    groupType.setSchemaExtensions(List.of());
 
     schemaRegistry.addSchema(ScimUser.class, List.of(ExampleObjectExtension.class));
-    schemaRegistry.addSchema(ScimGroup.class, null);
+    schemaRegistry.addSchema(ScimGroup.class);
 
     assertThat(schemaRegistry.getSchema(ScimUser.SCHEMA_URI)).isEqualTo(userSchema);
     assertThat(schemaRegistry.getAllSchemas()).containsOnly(userSchema, groupsSchema, extSchema);


### PR DESCRIPTION
`schemaRegistry.addSchema(<class>, null)` can now be `schemaRegistry.addSchema(<class>, null)`
