### PR TITLE
Apache Rat license scanning is not threadsafe

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,4 +22,4 @@
 # Runs License header checks with Apache Rat
 # ----------------------------------------------------------------------------
 
-./mvnw apache-rat:check
+./mvnw apache-rat:check -T1

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       name: "Apache Rat - Check"
       jobs_path: "rat / maven"
-      mvn: apache-rat:check
+      mvn: apache-rat:check -T1
       java-version: 17
       java-distribution: 'zulu'
     secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,9 @@
           <artifactId>apache-rat-plugin</artifactId>
           <version>0.17</version>
           <configuration>
+            <inputExcludeStd>ECLIPSE</inputExcludeStd>
+            <inputExcludeStd>IDEA</inputExcludeStd>
+            <inputExcludeStd>MAC</inputExcludeStd>
             <excludes>
               <exclude>**/*.md</exclude>
               <exclude>**/*.json</exclude>


### PR DESCRIPTION
It's unclear where the problem is, but running the build with one thread fixes issue
