### PR TITLE
Add Schema, ResourceType, and ServiceProviderConfiguration to Schema Registry

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/schema/SchemaRegistry.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/schema/SchemaRegistry.java
@@ -31,6 +31,7 @@ import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.schema.ResourceType;
 import org.apache.directory.scim.spec.schema.Schema;
 import org.apache.directory.scim.spec.schema.Schemas;
+import org.apache.directory.scim.spec.schema.ServiceProviderConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,10 @@ public class SchemaRegistry implements Serializable {
   private final Map<String, ResourceType> resourceTypeMap = new HashMap<>();
 
   private final Map<Class<? extends ScimResource>, Map<String, Class<? extends ScimExtension>>> resourceExtensionsMap = new HashMap<>();
+
+  public SchemaRegistry() {
+    addInternalSchemas();
+  }
 
   public Schema getSchema(String urn) {
     return schemaMap.get(urn);
@@ -105,6 +110,17 @@ public class SchemaRegistry implements Serializable {
         addExtension(clazz, scimExtension);
       }
     }
+  }
+
+  private void addInternalSchemas() {
+    addInternalSchema(Schema.class, Schema.SCHEMA);
+    addInternalSchema(ServiceProviderConfiguration.class, ServiceProviderConfiguration.SCHEMA);
+    addInternalSchema(ResourceType.class, ResourceType.SCHEMA);
+  }
+
+  private <T extends ScimResource> void addInternalSchema(Class<T> clazz, Schema schema) {
+    addSchemaToRegistry(schema);
+    addScimResourceSchemaUrn(schema.getUrn(), clazz);
   }
 
   private <T extends ScimResource> void addScimResourceSchemaUrn(String schemaUrn, Class<T> scimResourceClass) {

--- a/scim-core/src/test/java/org/apache/directory/scim/core/schema/SchemaRegistryTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/schema/SchemaRegistryTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.directory.scim.core.schema;
 
+import org.apache.directory.scim.spec.schema.ServiceProviderConfiguration;
 import org.apache.directory.scim.test.stub.ExampleObjectExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.apache.directory.scim.spec.resources.ScimUser;
@@ -61,8 +62,8 @@ public class SchemaRegistryTest {
     schemaRegistry.addSchema(ScimGroup.class);
 
     assertThat(schemaRegistry.getSchema(ScimUser.SCHEMA_URI)).isEqualTo(userSchema);
-    assertThat(schemaRegistry.getAllSchemas()).containsOnly(userSchema, groupsSchema, extSchema);
-    assertThat(schemaRegistry.getAllSchemaUrns()).containsOnly(ScimUser.SCHEMA_URI, ScimGroup.SCHEMA_URI, ExampleObjectExtension.URN);
+    assertThat(schemaRegistry.getAllSchemas()).containsOnly(Schema.SCHEMA, ResourceType.SCHEMA, ServiceProviderConfiguration.SCHEMA, userSchema, groupsSchema, extSchema);
+    assertThat(schemaRegistry.getAllSchemaUrns()).containsOnly(Schema.SCHEMA_URI, ResourceType.SCHEMA_URI, ServiceProviderConfiguration.SCHEMA_URI, ScimUser.SCHEMA_URI, ScimGroup.SCHEMA_URI, ExampleObjectExtension.URN);
     assertThat(schemaRegistry.getAllResourceTypes()).containsOnly(userType, groupType);
     assertThat(schemaRegistry.getResourceType(ScimUser.RESOURCE_NAME)).isEqualTo(userType);
     assertThat(schemaRegistry.getScimResourceClassFromEndpoint("/Users")).isEqualTo(ScimUser.class);

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -53,7 +53,6 @@ public abstract class ScimResource extends BaseResource<ScimResource> implements
   private static final Logger LOG = LoggerFactory.getLogger(ScimResource.class);
 
   @XmlElement
-  @NotNull
   @ScimAttribute(returned = Returned.ALWAYS)
   Meta meta;
 
@@ -156,7 +155,7 @@ public abstract class ScimResource extends BaseResource<ScimResource> implements
     return (T) extensions.remove(se.id());
   }
 
-  public @NotNull Meta getMeta() {
+  public Meta getMeta() {
     return this.meta;
   }
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
@@ -47,6 +47,7 @@ public class ResourceType extends ScimResourceWithOptionalId {
   
   public static final String RESOURCE_NAME = "ResourceType";
   public static final String SCHEMA_URI = "urn:ietf:params:scim:schemas:core:2.0:ResourceType";
+  public static final Schema SCHEMA = Schemas.schemaFor(ResourceType.class, SCHEMA_URI, RESOURCE_NAME, "Specifies the schema that describes a SCIM resource type");
   private static final long serialVersionUID = -696969911228870476L;
 
   public @Size(min = 1) String getName() {

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schema.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schema.java
@@ -19,12 +19,11 @@
 
 package org.apache.directory.scim.spec.schema;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import jakarta.xml.bind.annotation.*;
 import org.apache.directory.scim.spec.exception.ScimResourceInvalidException;
-import org.apache.directory.scim.spec.validator.Urn;
+import org.apache.directory.scim.spec.resources.ScimResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,21 +40,17 @@ import java.util.*;
  */
 @XmlRootElement(name = "schema")
 @XmlAccessorType(XmlAccessType.NONE)
-public class Schema implements AttributeContainer {
+public class Schema extends ScimResource implements AttributeContainer {
 
   private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
+  private static final long serialVersionUID = 1869782412244161741L;
   
   public static final String RESOURCE_NAME = "Schema";
   public static final String SCHEMA_URI = "urn:ietf:params:scim:schemas:core:2.0:Schema";
-  private static final long serialVersionUID = 1869782412244161741L;
+  public static final Schema SCHEMA = Schemas.schemaFor(Schema.class, SCHEMA_URI, RESOURCE_NAME, "Specifies the schema that describes a SCIM schema");
 
-  public @Urn @NotNull @Size(min = 1, max = 65535) String getId() {
-    return this.id;
-  }
-
-  public Schema setId(@Urn @NotNull @Size(min = 1, max = 65535) String id) {
-    this.id = id;
-    return this;
+  public Schema() {
+    super(SCHEMA_URI, RESOURCE_NAME);
   }
 
   public String getName() {
@@ -539,12 +534,6 @@ public class Schema implements AttributeContainer {
     }
 
   }
-  
-  @Urn
-  @NotNull
-  @Size(min = 1, max = 65535)
-  @XmlElement
-  String id;
 
   @XmlElement
   String name;
@@ -564,7 +553,7 @@ public class Schema implements AttributeContainer {
 
   @Override
   public String getUrn() {
-    return id;
+    return getBaseUrn();
   }
 
   public Set<Attribute> getAttributes() {

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
@@ -67,27 +67,30 @@ public final class Schemas {
   private Schemas() {}
 
   public static Schema schemaFor(Class<? extends ScimResource> clazz) throws ScimResourceInvalidException {
-    return generateSchema(clazz, getFieldsUpTo(clazz, BaseResource.class));
+    ScimResourceType srt = clazz.getAnnotation(ScimResourceType.class);
+    return schemaFor(clazz, srt.schema(), srt.name(), srt.description());
+  }
+
+  public static Schema schemaFor(Class<? extends ScimResource> clazz, String schemaUrn, String name, String description) throws ScimResourceInvalidException {
+    return generateSchema(clazz, schemaUrn, name, description, getFieldsUpTo(clazz, BaseResource.class));
   }
 
   public static Schema schemaForExtension(Class<? extends ScimExtension> clazz) throws ScimResourceInvalidException {
-    return generateSchema(clazz, getFieldsUpTo(clazz, Object.class));
+    ScimExtensionType set = clazz.getAnnotation(ScimExtensionType.class);
+    return generateSchema(clazz, set.id(), set.name(), set.description(), getFieldsUpTo(clazz, Object.class));
   }
 
-  private static Schema generateSchema(Class<?> clazz, List<Field> fieldList) throws ScimResourceInvalidException {
-
-    Schema schema = new Schema();
-
-    ScimResourceType srt = clazz.getAnnotation(ScimResourceType.class);
-    ScimExtensionType set = clazz.getAnnotation(ScimExtensionType.class);
-
-    if (srt == null && set == null) {
-      // TODO - throw?
-      log.error("Neither a ScimResourceType or ScimExtensionType annotation found");
+  private static Schema generateSchema(Class<?> clazz, String urn, String name, String description, List<Field> fieldList) throws ScimResourceInvalidException {
+    if (urn == null) {
+      throw new IllegalArgumentException("Cannot generate schema for null urn.");
     }
 
+    Schema schema = new Schema();
+    schema.setId(urn);
+    schema.setName(name);
+    schema.setDescription(description);
+
     log.debug("calling set attributes with " + fieldList.size() + " fields");
-    String urn = set != null ? set.id() : srt.schema();
     Set<String> invalidAttributes = new HashSet<>();
     Set<Schema.Attribute> createAttributes = createAttributes(urn, fieldList, invalidAttributes, clazz.getSimpleName());
     schema.setAttributes(createAttributes);
@@ -103,16 +106,6 @@ public final class Schemas {
       }
 
       throw new ScimResourceInvalidException(sb.toString());
-    }
-
-    if (srt != null) {
-      schema.setId(srt.schema());
-      schema.setDescription(srt.description());
-      schema.setName(srt.name());
-    } else {
-      schema.setId(set.id());
-      schema.setDescription(set.description());
-      schema.setName(set.name());
     }
 
     return schema;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
@@ -41,6 +41,7 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
 
   public static final String RESOURCE_NAME = "ServiceProviderConfig";
   public static final String SCHEMA_URI = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
+  public static final Schema SCHEMA = Schemas.schemaFor(ServiceProviderConfiguration.class, SCHEMA_URI, "Service Provider Configuration", "Specifies the schema that describes a SCIM schema");
   private static final long serialVersionUID = -6526116522184446474L;
 
   public String getDocumentationUrl() {

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemaTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/schema/SchemaTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SchemaTest {
 
@@ -87,17 +88,17 @@ public class SchemaTest {
     // representations meet the schema specification.
     if (schema != null) {
       Set<ConstraintViolation<Schema>> schemaViolations = validator.validate(schema);
-      assertTrue(schemaViolations.isEmpty());
+      assertThat(schemaViolations).isEmpty();
 
       for (Attribute attribute : schema.getAttributes()) {
         Set<ConstraintViolation<Attribute>> attributeViolations = validator.validate(attribute);
-        assertTrue(attributeViolations.isEmpty());
+        assertThat(attributeViolations).isEmpty();
       }
 
       Meta meta = schema.getMeta();
       if (meta != null) {
         Set<ConstraintViolation<Meta>> metaViolations = validator.validate(meta);
-        assertTrue(metaViolations.isEmpty());
+        assertThat(metaViolations).isEmpty();
       }
     }
   }


### PR DESCRIPTION
It's meta, but it's in the spec.

ScimResource.meta is no longer marked as NotNull, as this value shouldn't be set by a client.

Fixes: #1012
