### PR TITLE
Cleanup: Update to Java 17 patterns

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
@@ -51,7 +51,6 @@ import org.apache.directory.scim.spec.schema.Schema.Attribute.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.stream.Collectors.toList;
 
 /**
  * The default implementation of a PatchHandler that applies PatchOperations by walking a map equivalent
@@ -370,7 +369,7 @@ public class DefaultPatchHandler implements PatchHandler {
       Collection<Map<String, Object>> items = (Collection<Map<String, Object>>) sourceAsMap.get(attributeName);
       Predicate<Object> pred = FilterExpressions.inMemoryMap(valuePathExpression.getAttributeExpression(), schema);
 
-      Collection<Object> updatedCollection = items.stream()
+      List<Map<String, Object>> updatedCollection = items.stream()
         .map(item -> {
           // find items that need to be updated
           if (pred.test(item)) {
@@ -385,7 +384,7 @@ public class DefaultPatchHandler implements PatchHandler {
             }
           }
           return item;
-        }).collect(toList());
+        }).toList();
       sourceAsMap.put(attribute.getName(), updatedCollection);
     }
   }
@@ -499,7 +498,7 @@ public class DefaultPatchHandler implements PatchHandler {
 
           return (String) itemValue;
         })
-        .collect(toList());
+        .toList();
     }
   }
 }

--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/DefaultPatchHandler.java
@@ -102,10 +102,11 @@ public class DefaultPatchHandler implements PatchHandler {
     Map<String, Object> sourceAsMap = objectAsMap(original);
     for (PatchOperation patchOperation : patchOperations) {
       if (patchOperation.getPath() == null) {
-        if (!(patchOperation.getValue() instanceof Map)) {
+        if (!(patchOperation.getValue() instanceof Map<?, ?> map)) {
           throw new UnsupportedFilterException("Cannot apply patch. value is required");
         }
-        Map<String, Object> properties = (Map<String, Object>) patchOperation.getValue();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) map;
 
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
           // convert SCIM patch to RFC-6902 patch
@@ -277,8 +278,8 @@ public class DefaultPatchHandler implements PatchHandler {
         items = new ArrayList<>();
       }
 
-      if (value instanceof Collection) {
-        items.addAll((Collection<Object>) value);
+      if (value instanceof Collection<?> collection) {
+        items.addAll(collection);
       } else {
         items.add(value);
       }
@@ -313,10 +314,9 @@ public class DefaultPatchHandler implements PatchHandler {
       // values for example in the expression `emails[type eq "work"].value` with a patch value of `foo@example.com`
       // the map will contain `type: "work", value: "foo@example.com"`
       if (!matchFound) {
-        if (!(valuePathExpression.getAttributeExpression() instanceof AttributeComparisonExpression)) {
+        if (!(valuePathExpression.getAttributeExpression() instanceof AttributeComparisonExpression comparisonExpression)) {
           throw new UnsupportedFilterException("Attribute cannot be added, only comparison expressions are supported when the existing item does not exist.");
         }
-        AttributeComparisonExpression comparisonExpression = (AttributeComparisonExpression) valuePathExpression.getAttributeExpression();
         checkPrimary(subAttributeName, items, value);
 
         // Add a new mutable map
@@ -484,19 +484,19 @@ public class DefaultPatchHandler implements PatchHandler {
     private static List<String> azureQuirkValuesToRemove(Collection<?> listOfMaps, Attribute attribute) {
       return listOfMaps.stream()
         .map(item -> {
-          if (!(item instanceof Map)) {
+          if (!(item instanceof Map<?, ?> map)) {
             throw new IllegalArgumentException("Azure Remove Patch request quirk detected, but 'value' is not a list of maps");
           }
-          return (Map<?,?>) item;
+          return map;
         })
         .map(item -> {
           Attribute valueAttribute = attribute.getAttribute(VALUE_ATTRIBUTE_NAME);
           Object itemValue = item.get(valueAttribute.getName());
-          if (!(itemValue instanceof String)) {
+          if (!(itemValue instanceof String s)) {
             throw new IllegalArgumentException("Azure Remove Patch request quirk detected, but item 'value' is not a string");
           }
 
-          return (String) itemValue;
+          return s;
         })
         .toList();
     }

--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/ETag.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/ETag.java
@@ -105,11 +105,9 @@ public class ETag {
       return true;
     }
 
-    if ( !( obj instanceof ETag ) ) {
+    if ( !( obj instanceof ETag that ) ) {
       return false;
     }
-    
-    ETag that = (ETag)obj;
     
     if ( value == null ) {
       return weak = that.weak && that.value == null;

--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/RepositoryRegistry.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/RepositoryRegistry.java
@@ -91,8 +91,7 @@ public class RepositoryRegistry {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof RepositoryRegistry)) return false;
-    final RepositoryRegistry other = (RepositoryRegistry) o;
+    if (!(o instanceof RepositoryRegistry other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$schemaRegistry = this.getSchemaRegistry();
     final Object other$schemaRegistry = other.getSchemaRegistry();

--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/extensions/ClientFilterException.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/extensions/ClientFilterException.java
@@ -43,8 +43,7 @@ public class ClientFilterException extends Exception {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ClientFilterException)) return false;
-    final ClientFilterException other = (ClientFilterException) o;
+    if (!(o instanceof ClientFilterException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     if (this.getStatus() != other.getStatus()) return false;

--- a/scim-core/src/main/java/org/apache/directory/scim/core/spi/ScimpleComponents.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/spi/ScimpleComponents.java
@@ -30,7 +30,6 @@ import org.apache.directory.scim.core.repository.RepositoryRegistry;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.spec.resources.ScimResource;
 
-import java.util.stream.Collectors;
 
 @Dependent
 public class ScimpleComponents {
@@ -45,7 +44,7 @@ public class ScimpleComponents {
   @ApplicationScoped
   public RepositoryRegistry repositoryRegistry(SchemaRegistry schemaRegistry, Instance<Repository<? extends ScimResource>> repositoryInstances) {
     RepositoryRegistry registry = new RepositoryRegistry(schemaRegistry);
-    registry.registerRepositories(repositoryInstances.stream().collect(Collectors.toList()));
+    registry.registerRepositories(repositoryInstances.stream().toList());
     return registry;
   }
 

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/extensions/LuckyNumberExtension.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/extensions/LuckyNumberExtension.java
@@ -68,8 +68,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Named
 @ApplicationScoped
@@ -143,7 +142,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
             .skip(startIndex)
             .limit(count)
             .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-            .collect(Collectors.toList());
+            .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Repository<ScimUser> with a memory-based
@@ -188,7 +187,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/extensions/LuckyNumberExtension.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/extensions/LuckyNumberExtension.java
@@ -68,8 +68,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Named
 @ApplicationScoped
@@ -143,7 +142,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Repository<ScimUser> with a memory-based
@@ -188,7 +187,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/extensions/LuckyNumberExtension.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/extensions/LuckyNumberExtension.java
@@ -67,8 +67,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 @Named
 @ApplicationScoped
@@ -141,7 +140,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Repository<ScimUser> with a memory-based
@@ -187,7 +186,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/extensions/LuckyNumberExtension.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/extensions/LuckyNumberExtension.java
@@ -67,8 +67,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 @Named
 @ApplicationScoped
@@ -141,7 +140,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Repository<ScimUser> with a memory-based
@@ -187,7 +186,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/extensions/LuckyNumberExtension.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/extensions/LuckyNumberExtension.java
@@ -67,8 +67,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 public class InMemoryGroupService implements Repository<ScimGroup> {
@@ -137,7 +136,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Provider<User> with a memory-based
@@ -183,7 +182,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/extensions/LuckyNumberExtension.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/extensions/LuckyNumberExtension.java
@@ -67,8 +67,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 public class InMemoryGroupService implements Repository<ScimGroup> {
@@ -137,7 +136,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Provider<User> with a memory-based
@@ -183,7 +182,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server/src/main/java/org/apache/directory/scim/server/configuration/ServerConfiguration.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/configuration/ServerConfiguration.java
@@ -222,8 +222,7 @@ public class ServerConfiguration {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ServerConfiguration)) return false;
-    final ServerConfiguration other = (ServerConfiguration) o;
+    if (!(o instanceof ServerConfiguration other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$id = this.getId();
     final Object other$id = other.getId();

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToCreateResourceException.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToCreateResourceException.java
@@ -43,8 +43,7 @@ public class UnableToCreateResourceException extends ResourceException {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof UnableToCreateResourceException)) return false;
-    final UnableToCreateResourceException other = (UnableToCreateResourceException) o;
+    if (!(o instanceof UnableToCreateResourceException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     return true;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToDeleteResourceException.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToDeleteResourceException.java
@@ -43,8 +43,7 @@ public class UnableToDeleteResourceException extends ResourceException {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof UnableToDeleteResourceException)) return false;
-    final UnableToDeleteResourceException other = (UnableToDeleteResourceException) o;
+    if (!(o instanceof UnableToDeleteResourceException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     return true;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToResolveIdResourceException.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToResolveIdResourceException.java
@@ -44,8 +44,7 @@ public class UnableToResolveIdResourceException extends ResourceException {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof UnableToResolveIdResourceException)) return false;
-    final UnableToResolveIdResourceException other = (UnableToResolveIdResourceException) o;
+    if (!(o instanceof UnableToResolveIdResourceException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     return true;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToRetrieveExtensionsResourceException.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToRetrieveExtensionsResourceException.java
@@ -43,8 +43,7 @@ public class UnableToRetrieveExtensionsResourceException extends ResourceExcepti
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof UnableToRetrieveExtensionsResourceException)) return false;
-    final UnableToRetrieveExtensionsResourceException other = (UnableToRetrieveExtensionsResourceException) o;
+    if (!(o instanceof UnableToRetrieveExtensionsResourceException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     return true;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToRetrieveResourceException.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToRetrieveResourceException.java
@@ -44,8 +44,7 @@ public class UnableToRetrieveResourceException extends ResourceException {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof UnableToRetrieveResourceException)) return false;
-    final UnableToRetrieveResourceException other = (UnableToRetrieveResourceException) o;
+    if (!(o instanceof UnableToRetrieveResourceException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     return true;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToUpdateResourceException.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/exception/UnableToUpdateResourceException.java
@@ -43,8 +43,7 @@ public class UnableToUpdateResourceException extends ResourceException {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof UnableToUpdateResourceException)) return false;
-    final UnableToUpdateResourceException other = (UnableToUpdateResourceException) o;
+    if (!(o instanceof UnableToUpdateResourceException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     return true;

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/BulkResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/BulkResourceImpl.java
@@ -154,17 +154,15 @@ public class BulkResourceImpl implements BulkResource {
       // bad/missing input for method
       if (method != null && !(operationRequest.getResponse() instanceof ErrorResponse)) {
         switch (method) {
-        case POST:
-        case PUT: {
+        case POST, PUT -> {
           if (operationRequest.getData() == null) {
             errorOccurred = true;
 
             createAndSetErrorResponse(operationRequest, Status.BAD_REQUEST, "data not provided");
           }
         }
-          break;
 
-        case DELETE: {
+        case DELETE -> {
           String path = operationRequest.getPath();
 
           if (path == null) {
@@ -187,18 +185,15 @@ public class BulkResourceImpl implements BulkResource {
             }
           }
         }
-          break;
 
-        case PATCH: {
+        case PATCH -> {
           errorOccurred = true;
 
           createAndSetErrorResponse(operationRequest, Status.NOT_IMPLEMENTED, "Method not implemented: PATCH");
         }
-          break;
 
-        default: {
+        default -> {
         }
-          break;
         }
       } else if (method == null) {
         errorOccurred = true;
@@ -411,7 +406,7 @@ public class BulkResourceImpl implements BulkResource {
     Repository<ScimResource> repository = repositoryRegistry.getRepository(scimResourceClass);
 
     switch (bulkOperationMethod) {
-    case POST: {
+    case POST -> {
       log.debug("POST: {}", scimResource);
 
       this.resolveTopLevel(unresolveds, operationResult, bulkIdKeyToOperationResult);
@@ -439,9 +434,8 @@ public class BulkResourceImpl implements BulkResource {
       operationResult.setPath(null);
       operationResult.setStatus(StatusWrapper.wrap(Status.CREATED));
     }
-      break;
 
-    case DELETE: {
+    case DELETE -> {
       log.debug("DELETE: {}", operationResult.getPath());
 
       String scimResourceId = operationResult.getPath()
@@ -452,9 +446,8 @@ public class BulkResourceImpl implements BulkResource {
       repository.delete(scimResourceId);
       operationResult.setStatus(StatusWrapper.wrap(Status.NO_CONTENT));
     }
-      break;
 
-    case PUT: {
+    case PUT -> {
       log.debug("PUT: {}", scimResource);
 
       this.resolveTopLevel(unresolveds, operationResult, bulkIdKeyToOperationResult);
@@ -470,16 +463,14 @@ public class BulkResourceImpl implements BulkResource {
         operationResult.setStatus(StatusWrapper.wrap(Status.NOT_FOUND));
       }
     }
-      break;
 
-    default: {
+    default -> {
       BulkOperation.Method method = operationResult.getMethod();
       String detail = "Method not allowed: " + method;
 
       log.error("Received unallowed method: {}", method);
       createAndSetErrorResponse(operationResult, Status.METHOD_NOT_ALLOWED, detail);
     }
-      break;
     }
   }
 

--- a/scim-server/src/main/java/org/apache/directory/scim/server/rest/BulkResourceImpl.java
+++ b/scim-server/src/main/java/org/apache/directory/scim/server/rest/BulkResourceImpl.java
@@ -539,7 +539,7 @@ public class BulkResourceImpl implements BulkResource {
     }
   }
 
-  private static abstract class UnresolvedTopLevel {
+  private static sealed abstract class UnresolvedTopLevel permits UnresolvedTopLevelBulkId, UnresolvedTopLevelComplex {
     protected final Schema.AttributeAccessor accessor;
 
     public UnresolvedTopLevel(Schema.AttributeAccessor accessor) {
@@ -549,7 +549,7 @@ public class BulkResourceImpl implements BulkResource {
     public abstract void resolve(ScimResource scimResource, Map<String, BulkOperation> bulkIdKeyToOperationResult) throws UnresolvableOperationException;
   }
 
-  private static class UnresolvedTopLevelBulkId extends UnresolvedTopLevel {
+  private static final class UnresolvedTopLevelBulkId extends UnresolvedTopLevel {
     private final String unresolvedBulkIdKey;
 
     public UnresolvedTopLevelBulkId(Schema.AttributeAccessor accessor, String bulkIdKey) {
@@ -573,7 +573,7 @@ public class BulkResourceImpl implements BulkResource {
     }
   }
 
-  private static class UnresolvedTopLevelComplex extends UnresolvedTopLevel {
+  private static final class UnresolvedTopLevelComplex extends UnresolvedTopLevel {
     public final Object complex;
     public final List<UnresolvedComplex> unresolveds;
 

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 @Named
 @ApplicationScoped
@@ -141,7 +140,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
@@ -45,7 +45,6 @@ import org.apache.directory.scim.spec.resources.ScimUser;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Repository<ScimUser> with a memory-based
@@ -181,7 +180,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/LuckyNumberExtension.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/LuckyNumberExtension.java
@@ -67,8 +67,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/adapter/FilterWrapper.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/adapter/FilterWrapper.java
@@ -60,8 +60,7 @@ final public class FilterWrapper {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof FilterWrapper)) return false;
-    final FilterWrapper other = (FilterWrapper) o;
+    if (!(o instanceof FilterWrapper other)) return false;
     final Object this$filter = this.getFilter();
     final Object other$filter = other.getFilter();
     if (this$filter == null ? other$filter != null : !this$filter.equals(other$filter)) return false;

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkOperation.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkOperation.java
@@ -76,8 +76,7 @@ public class BulkOperation implements Serializable {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof StatusWrapper)) return false;
-      final StatusWrapper other = (StatusWrapper) o;
+      if (!(o instanceof StatusWrapper other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$code = this.getCode();
       final Object other$code = other.getCode();
@@ -200,8 +199,7 @@ public class BulkOperation implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof BulkOperation)) return false;
-    final BulkOperation other = (BulkOperation) o;
+    if (!(o instanceof BulkOperation other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$method = this.getMethod();
     final Object other$method = other.getMethod();

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkRequest.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkRequest.java
@@ -72,8 +72,7 @@ public class BulkRequest extends BaseResource<BulkRequest> {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof BulkRequest)) return false;
-    final BulkRequest other = (BulkRequest) o;
+    if (!(o instanceof BulkRequest other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$failOnErrors = this.getFailOnErrors();

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkResponse.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/BulkResponse.java
@@ -83,8 +83,7 @@ public class BulkResponse extends BaseResource<BulkResponse> {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof BulkResponse)) return false;
-    final BulkResponse other = (BulkResponse) o;
+    if (!(o instanceof BulkResponse other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$operations = this.getOperations();

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ErrorResponse.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ErrorResponse.java
@@ -105,8 +105,7 @@ public class ErrorResponse extends BaseResource<ErrorResponse> {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ErrorResponse)) return false;
-    final ErrorResponse other = (ErrorResponse) o;
+    if (!(o instanceof ErrorResponse other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$detail = this.getDetail();

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ListResponse.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/ListResponse.java
@@ -96,8 +96,7 @@ public class ListResponse<T> extends BaseResource<ListResponse<T>> {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ListResponse)) return false;
-    final ListResponse<?> other = (ListResponse<?>) o;
+    if (!(o instanceof ListResponse other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     if (this.getTotalResults() != other.getTotalResults()) return false;

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/PatchRequest.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/PatchRequest.java
@@ -64,8 +64,7 @@ public class PatchRequest extends BaseResource<PatchRequest> {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof PatchRequest)) return false;
-    final PatchRequest other = (PatchRequest) o;
+    if (!(o instanceof PatchRequest other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$patchOperationList = this.getPatchOperationList();

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/SearchRequest.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/data/SearchRequest.java
@@ -164,8 +164,7 @@ public class SearchRequest extends BaseResource<SearchRequest> {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof SearchRequest)) return false;
-    final SearchRequest other = (SearchRequest) o;
+    if (!(o instanceof SearchRequest other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$attributes = this.getAttributes();

--- a/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/exception/ScimException.java
+++ b/scim-spec/scim-spec-protocol/src/main/java/org/apache/directory/scim/protocol/exception/ScimException.java
@@ -60,8 +60,7 @@ public class ScimException extends Exception {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ScimException)) return false;
-    final ScimException other = (ScimException) o;
+    if (!(o instanceof ScimException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$error = this.getError();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/exception/ResourceException.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/exception/ResourceException.java
@@ -43,8 +43,7 @@ public class ResourceException extends Exception {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ResourceException)) return false;
-    final ResourceException other = (ResourceException) o;
+    if (!(o instanceof ResourceException other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     if (this.getStatus() != other.getStatus()) return false;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/extension/EnterpriseExtension.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/extension/EnterpriseExtension.java
@@ -98,8 +98,7 @@ public class EnterpriseExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof EnterpriseExtension)) return false;
-    final EnterpriseExtension other = (EnterpriseExtension) o;
+    if (!(o instanceof EnterpriseExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$employeeNumber = this.getEmployeeNumber();
     final Object other$employeeNumber = other.getEmployeeNumber();
@@ -198,8 +197,7 @@ public class EnterpriseExtension implements ScimExtension {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof Manager)) return false;
-      final Manager other = (Manager) o;
+      if (!(o instanceof Manager other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$value = this.getValue();
       final Object other$value = other.getValue();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/AttributeComparisonExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/AttributeComparisonExpression.java
@@ -91,14 +91,14 @@ public final class AttributeComparisonExpression implements FilterExpression, Va
 
     if (this.compareValue == null) {
       compareValueString = "null";
-    } else if (this.compareValue instanceof String) {
-      compareValueString = QUOTE + this.compareValue + QUOTE;
-    } else if (this.compareValue instanceof Date date1) {
-      compareValueString = QUOTE + toDateTimeString(date1) + QUOTE;
-    } else if (this.compareValue instanceof LocalDate date) {
-      compareValueString = QUOTE + toDateString(date) + QUOTE;
-    } else if (this.compareValue instanceof LocalDateTime time) {
-      compareValueString = QUOTE + toDateTimeString(time) + QUOTE;
+    } else if (this.compareValue instanceof String s) {
+      compareValueString = QUOTE + s + QUOTE;
+    } else if (this.compareValue instanceof Date date) {
+      compareValueString = QUOTE + toDateTimeString(date) + QUOTE;
+    } else if (this.compareValue instanceof LocalDate localDate) {
+      compareValueString = QUOTE + toDateString(localDate) + QUOTE;
+    } else if (this.compareValue instanceof LocalDateTime localDateTime) {
+      compareValueString = QUOTE + toDateTimeString(localDateTime) + QUOTE;
     } else {
       compareValueString = this.compareValue.toString();
     }
@@ -119,8 +119,7 @@ public final class AttributeComparisonExpression implements FilterExpression, Va
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof AttributeComparisonExpression)) return false;
-    final AttributeComparisonExpression other = (AttributeComparisonExpression) o;
+    if (!(o instanceof AttributeComparisonExpression other)) return false;
     final Object this$attributePath = this.getAttributePath();
     final Object other$attributePath = other.getAttributePath();
     if (this$attributePath == null ? other$attributePath != null : !this$attributePath.equals(other$attributePath))

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/AttributePresentExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/AttributePresentExpression.java
@@ -59,8 +59,7 @@ public final class AttributePresentExpression implements FilterExpression, Value
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof AttributePresentExpression)) return false;
-    final AttributePresentExpression other = (AttributePresentExpression) o;
+    if (!(o instanceof AttributePresentExpression other)) return false;
     final Object this$attributePath = this.getAttributePath();
     final Object other$attributePath = other.getAttributePath();
     if (this$attributePath == null ? other$attributePath != null : !this$attributePath.equals(other$attributePath))

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/Filter.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/Filter.java
@@ -119,8 +119,7 @@ public class Filter implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Filter)) return false;
-    final Filter other = (Filter) o;
+    if (!(o instanceof Filter other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$expression = this.getExpression();
     final Object other$expression = other.getExpression();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/FilterExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/FilterExpression.java
@@ -22,7 +22,8 @@ package org.apache.directory.scim.spec.filter;
 import java.io.Serializable;
 import java.util.function.Function;
 
-public interface FilterExpression extends Serializable {
+public sealed interface FilterExpression extends Serializable
+  permits AttributeComparisonExpression, AttributePresentExpression, GroupExpression, LogicalExpression, ValuePathExpression {
   
   String toFilter();
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/FilterResponse.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/FilterResponse.java
@@ -53,8 +53,7 @@ public class FilterResponse<T> {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof FilterResponse)) return false;
-    final FilterResponse<?> other = (FilterResponse<?>) o;
+    if (!(o instanceof FilterResponse other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$resources = this.getResources();
     final Object other$resources = other.getResources();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/GroupExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/GroupExpression.java
@@ -19,7 +19,7 @@
 
 package org.apache.directory.scim.spec.filter;
 
-public class GroupExpression implements FilterExpression, ValueFilterExpression {
+public final class GroupExpression implements FilterExpression, ValueFilterExpression {
 
   boolean not;
   FilterExpression filterExpression;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/GroupExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/GroupExpression.java
@@ -66,8 +66,7 @@ public class GroupExpression implements FilterExpression, ValueFilterExpression 
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof GroupExpression)) return false;
-    final GroupExpression other = (GroupExpression) o;
+    if (!(o instanceof GroupExpression other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.isNot() != other.isNot()) return false;
     final Object this$filterExpression = this.getFilterExpression();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/LogicalExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/LogicalExpression.java
@@ -19,7 +19,7 @@
 
 package org.apache.directory.scim.spec.filter;
 
-public class LogicalExpression implements FilterExpression, ValueFilterExpression {
+public final class LogicalExpression implements FilterExpression, ValueFilterExpression {
 
   FilterExpression left;
   LogicalOperator operator;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/LogicalExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/LogicalExpression.java
@@ -90,8 +90,7 @@ public class LogicalExpression implements FilterExpression, ValueFilterExpressio
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LogicalExpression)) return false;
-    final LogicalExpression other = (LogicalExpression) o;
+    if (!(o instanceof LogicalExpression other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$left = this.getLeft();
     final Object other$left = other.getLeft();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/PageRequest.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/PageRequest.java
@@ -43,8 +43,7 @@ public class PageRequest {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof PageRequest)) return false;
-    final PageRequest other = (PageRequest) o;
+    if (!(o instanceof PageRequest other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$startIndex = this.getStartIndex();
     final Object other$startIndex = other.getStartIndex();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/SimpleLogicalFilterBuilder.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/SimpleLogicalFilterBuilder.java
@@ -43,11 +43,10 @@ abstract class SimpleLogicalFilterBuilder implements FilterBuilder {
     if (filterExpression == null) {
       filterExpression = expression;
     } else {
-      if (!(filterExpression instanceof LogicalExpression)) {
+      if (!(filterExpression instanceof LogicalExpression le)) {
         throw new IllegalStateException("Invalid filter state");
       }
 
-      LogicalExpression le = (LogicalExpression) filterExpression;
       le.setRight(groupIfNeeded(expression));
     }
   }

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/SortRequest.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/SortRequest.java
@@ -45,8 +45,7 @@ public class SortRequest {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof SortRequest)) return false;
-    final SortRequest other = (SortRequest) o;
+    if (!(o instanceof SortRequest other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$sortBy = this.getSortBy();
     final Object other$sortBy = other.getSortBy();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/ValueFilterExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/ValueFilterExpression.java
@@ -19,7 +19,8 @@
 
 package org.apache.directory.scim.spec.filter;
 
-public interface ValueFilterExpression {
+public sealed interface ValueFilterExpression
+  permits AttributeComparisonExpression, AttributePresentExpression, GroupExpression, LogicalExpression {
 
   String toFilter();
 

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/ValuePathExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/ValuePathExpression.java
@@ -23,7 +23,7 @@ import org.apache.directory.scim.spec.filter.attribute.AttributeReference;
 
 import java.io.Serial;
 
-public class ValuePathExpression implements FilterExpression {
+public final class ValuePathExpression implements FilterExpression {
 
   @Serial
   private static final long serialVersionUID = 2615135752981305135L;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/ValuePathExpression.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/ValuePathExpression.java
@@ -126,8 +126,7 @@ public class ValuePathExpression implements FilterExpression {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ValuePathExpression)) return false;
-    final ValuePathExpression other = (ValuePathExpression) o;
+    if (!(o instanceof ValuePathExpression other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$attributePath = this.getAttributePath();
     final Object other$attributePath = other.getAttributePath();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/attribute/AttributeReference.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/attribute/AttributeReference.java
@@ -155,8 +155,7 @@ public class AttributeReference implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof AttributeReference)) return false;
-    final AttributeReference other = (AttributeReference) o;
+    if (!(o instanceof AttributeReference other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$urn = this.getUrn();
     final Object other$urn = other.getUrn();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/attribute/AttributeReferenceListWrapper.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/attribute/AttributeReferenceListWrapper.java
@@ -73,8 +73,7 @@ public class AttributeReferenceListWrapper {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof AttributeReferenceListWrapper)) return false;
-    final AttributeReferenceListWrapper other = (AttributeReferenceListWrapper) o;
+    if (!(o instanceof AttributeReferenceListWrapper other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$attributeReferences = this.getAttributeReferences();
     final Object other$attributeReferences = other.getAttributeReferences();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/patch/PatchOperation.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/patch/PatchOperation.java
@@ -72,8 +72,7 @@ public class PatchOperation implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof PatchOperation)) return false;
-    final PatchOperation other = (PatchOperation) o;
+    if (!(o instanceof PatchOperation other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$operation = this.getOperation();
     final Object other$operation = other.getOperation();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/patch/PatchOperationPath.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/patch/PatchOperationPath.java
@@ -84,8 +84,7 @@ public class PatchOperationPath implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof PatchOperationPath)) return false;
-    final PatchOperationPath other = (PatchOperationPath) o;
+    if (!(o instanceof PatchOperationPath other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$valuePathExpression = this.getValuePathExpression();
     final Object other$valuePathExpression = other.getValuePathExpression();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Address.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Address.java
@@ -163,8 +163,7 @@ public class Address implements Serializable, TypedAttribute {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Address)) return false;
-    final Address other = (Address) o;
+    if (!(o instanceof Address other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$type = this.getType();
     final Object other$type = other.getType();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/BaseResource.java
@@ -80,8 +80,7 @@ public abstract class BaseResource<SELF extends BaseResource<SELF>> implements S
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof BaseResource)) return false;
-    final BaseResource<?> other = (BaseResource<?>) o;
+    if (!(o instanceof BaseResource other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$schemas = this.getSchemas();
     final Object other$schemas = other.getSchemas();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Email.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Email.java
@@ -98,8 +98,7 @@ public class Email implements Serializable, TypedAttribute {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Email)) return false;
-    final Email other = (Email) o;
+    if (!(o instanceof Email other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$type = this.getType();
     final Object other$type = other.getType();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Entitlement.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Entitlement.java
@@ -98,8 +98,7 @@ public class Entitlement implements Serializable, TypedAttribute {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Entitlement)) return false;
-    final Entitlement other = (Entitlement) o;
+    if (!(o instanceof Entitlement other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$type = this.getType();
     final Object other$type = other.getType();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Im.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Im.java
@@ -98,8 +98,7 @@ public class Im implements Serializable, TypedAttribute {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Im)) return false;
-    final Im other = (Im) o;
+    if (!(o instanceof Im other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$type = this.getType();
     final Object other$type = other.getType();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Name.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Name.java
@@ -126,8 +126,7 @@ public class Name implements Serializable  {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Name)) return false;
-    final Name other = (Name) o;
+    if (!(o instanceof Name other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$familyName = this.getFamilyName();
     final Object other$familyName = other.getFamilyName();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/PhoneNumber.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/PhoneNumber.java
@@ -575,8 +575,7 @@ public class PhoneNumber implements Serializable, TypedAttribute {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof PhoneNumberBuilder)) return false;
-      final PhoneNumberBuilder other = (PhoneNumberBuilder) o;
+      if (!(o instanceof PhoneNumberBuilder other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$number = this.getNumber();
       final Object other$number = other.getNumber();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Photo.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Photo.java
@@ -98,8 +98,7 @@ public class Photo implements Serializable, TypedAttribute {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Photo)) return false;
-    final Photo other = (Photo) o;
+    if (!(o instanceof Photo other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$value = this.getValue();
     final Object other$value = other.getValue();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Role.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/Role.java
@@ -98,8 +98,7 @@ public class Role implements Serializable, TypedAttribute {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Role)) return false;
-    final Role other = (Role) o;
+    if (!(o instanceof Role other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$type = this.getType();
     final Object other$type = other.getType();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimGroup.java
@@ -127,8 +127,7 @@ public class ScimGroup extends ScimResource implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ScimGroup)) return false;
-    final ScimGroup other = (ScimGroup) o;
+    if (!(o instanceof ScimGroup other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$displayName = this.getDisplayName();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResource.java
@@ -195,8 +195,7 @@ public abstract class ScimResource extends BaseResource<ScimResource> implements
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ScimResource)) return false;
-    final ScimResource other = (ScimResource) o;
+    if (!(o instanceof ScimResource other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$meta = this.getMeta();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResourceWithOptionalId.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimResourceWithOptionalId.java
@@ -59,8 +59,7 @@ public abstract class ScimResourceWithOptionalId extends ScimResource {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ScimResourceWithOptionalId)) return false;
-    final ScimResourceWithOptionalId other = (ScimResourceWithOptionalId) o;
+    if (!(o instanceof ScimResourceWithOptionalId other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$id = this.getId();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/ScimUser.java
@@ -394,8 +394,7 @@ public class ScimUser extends ScimResource implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ScimUser)) return false;
-    final ScimUser other = (ScimUser) o;
+    if (!(o instanceof ScimUser other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$active = this.getActive();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/X509Certificate.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/resources/X509Certificate.java
@@ -94,8 +94,7 @@ public class X509Certificate implements Serializable, TypedAttribute {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof X509Certificate)) return false;
-    final X509Certificate other = (X509Certificate) o;
+    if (!(o instanceof X509Certificate other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$type = this.getType();
     final Object other$type = other.getType();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Meta.java
@@ -119,8 +119,7 @@ public class Meta implements Serializable {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Meta)) return false;
-    final Meta other = (Meta) o;
+    if (!(o instanceof Meta other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$resourceType = this.getResourceType();
     final Object other$resourceType = other.getResourceType();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ResourceType.java
@@ -103,8 +103,7 @@ public class ResourceType extends ScimResourceWithOptionalId {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ResourceType)) return false;
-    final ResourceType other = (ResourceType) o;
+    if (!(o instanceof ResourceType other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$name = this.getName();
@@ -180,8 +179,7 @@ public class ResourceType extends ScimResourceWithOptionalId {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof SchemaExtensionConfiguration)) return false;
-      final SchemaExtensionConfiguration other = (SchemaExtensionConfiguration) o;
+      if (!(o instanceof SchemaExtensionConfiguration other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$schemaUrn = this.getSchemaUrn();
       final Object other$schemaUrn = other.getSchemaUrn();

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schema.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schema.java
@@ -93,8 +93,7 @@ public class Schema extends ScimResource implements AttributeContainer {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof Schema)) return false;
-    final Schema other = (Schema) o;
+    if (!(o instanceof Schema other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$id = this.getId();
     final Object other$id = other.getId();
@@ -315,8 +314,7 @@ public class Schema extends ScimResource implements AttributeContainer {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof Attribute)) return false;
-      final Attribute other = (Attribute) o;
+      if (!(o instanceof Attribute other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$name = this.getName();
       final Object other$name = other.getName();
@@ -659,8 +657,7 @@ public class Schema extends ScimResource implements AttributeContainer {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof FieldAttributeAccessor)) return false;
-      final FieldAttributeAccessor other = (FieldAttributeAccessor) o;
+      if (!(o instanceof FieldAttributeAccessor other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$field = this.field;
       final Object other$field = other.field;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/Schemas.java
@@ -96,16 +96,13 @@ public final class Schemas {
     schema.setAttributes(createAttributes);
 
     if (!invalidAttributes.isEmpty()) {
-      StringBuilder sb = new StringBuilder();
+      String message = """
+          Scim attributes cannot be primitive types unless they are required.  \
+          The following values were found that are primitive and not required
 
-      sb.append("Scim attributes cannot be primitive types unless they are required.  The following values were found that are primitive and not required\n\n");
+          """ + String.join("\n", invalidAttributes) + "\n";
 
-      for (String s : invalidAttributes) {
-        sb.append(s);
-        sb.append("\n");
-      }
-
-      throw new ScimResourceInvalidException(sb.toString());
+      throw new ScimResourceInvalidException(message);
     }
 
     return schema;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/schema/ServiceProviderConfiguration.java
@@ -124,8 +124,7 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ServiceProviderConfiguration)) return false;
-    final ServiceProviderConfiguration other = (ServiceProviderConfiguration) o;
+    if (!(o instanceof ServiceProviderConfiguration other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (!super.equals(o)) return false;
     final Object this$documentationUrl = this.getDocumentationUrl();
@@ -238,8 +237,7 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof AuthenticationSchema)) return false;
-      final AuthenticationSchema other = (AuthenticationSchema) o;
+      if (!(o instanceof AuthenticationSchema other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$type = this.getType();
       final Object other$type = other.getType();
@@ -387,8 +385,7 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof SupportedConfiguration)) return false;
-      final SupportedConfiguration other = (SupportedConfiguration) o;
+      if (!(o instanceof SupportedConfiguration other)) return false;
       if (!other.canEqual((Object) this)) return false;
       if (this.isSupported() != other.isSupported()) return false;
       return true;
@@ -440,8 +437,7 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof BulkConfiguration)) return false;
-      final BulkConfiguration other = (BulkConfiguration) o;
+      if (!(o instanceof BulkConfiguration other)) return false;
       if (!other.canEqual((Object) this)) return false;
       if (!super.equals(o)) return false;
       if (this.getMaxOperations() != other.getMaxOperations()) return false;
@@ -482,8 +478,7 @@ public class ServiceProviderConfiguration extends ScimResourceWithOptionalId {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof FilterConfiguration)) return false;
-      final FilterConfiguration other = (FilterConfiguration) o;
+      if (!(o instanceof FilterConfiguration other)) return false;
       if (!other.canEqual((Object) this)) return false;
       if (!super.equals(o)) return false;
       if (this.getMaxResults() != other.getMaxResults()) return false;

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/AllSchemaTypesExtension.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/AllSchemaTypesExtension.java
@@ -387,8 +387,7 @@ public class AllSchemaTypesExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof AllSchemaTypesExtension)) return false;
-    final AllSchemaTypesExtension other = (AllSchemaTypesExtension) o;
+    if (!(o instanceof AllSchemaTypesExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$string1 = this.getString1();
     final Object other$string1 = other.getString1();

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexType.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexType.java
@@ -44,8 +44,7 @@ public class ComplexType {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ComplexType)) return false;
-    final ComplexType other = (ComplexType) o;
+    if (!(o instanceof ComplexType other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$firstAttribute = this.getFirstAttribute();
     final Object other$firstAttribute = other.getFirstAttribute();

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexTypeExtension.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/ComplexTypeExtension.java
@@ -56,8 +56,7 @@ public class ComplexTypeExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ComplexTypeExtension)) return false;
-    final ComplexTypeExtension other = (ComplexTypeExtension) o;
+    if (!(o instanceof ComplexTypeExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$complexType = this.getComplexType();
     final Object other$complexType = other.getComplexType();

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/LuckyNumberExtension.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/LuckyNumberExtension.java
@@ -67,8 +67,7 @@ public class LuckyNumberExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof LuckyNumberExtension)) return false;
-    final LuckyNumberExtension other = (LuckyNumberExtension) o;
+    if (!(o instanceof LuckyNumberExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     if (this.getLuckyNumber() != other.getLuckyNumber()) return false;
     return true;

--- a/scim-test/src/main/java/org/apache/directory/scim/test/assertj/IterablePatchOperationAssert.java
+++ b/scim-test/src/main/java/org/apache/directory/scim/test/assertj/IterablePatchOperationAssert.java
@@ -25,7 +25,6 @@ import org.assertj.core.api.Condition;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class IterablePatchOperationAssert extends AbstractIterableAssert<IterablePatchOperationAssert, Iterable<? extends PatchOperation>, PatchOperation, PatchOperationAssert> {
 
@@ -60,7 +59,7 @@ public class IterablePatchOperationAssert extends AbstractIterableAssert<Iterabl
     @SafeVarargs
     public final IterablePatchOperationAssert containsOnly(Condition<PatchOperation>... conditions) {
       isNotNull();
-      return containsOnly(Arrays.stream(conditions).collect(Collectors.toList()));
+      return containsOnly(Arrays.stream(conditions).toList());
     }
 
   @SafeVarargs

--- a/scim-test/src/main/java/org/apache/directory/scim/test/stub/ExampleObjectExtension.java
+++ b/scim-test/src/main/java/org/apache/directory/scim/test/stub/ExampleObjectExtension.java
@@ -155,8 +155,7 @@ public class ExampleObjectExtension implements ScimExtension {
 
   public boolean equals(final Object o) {
     if (o == this) return true;
-    if (!(o instanceof ExampleObjectExtension)) return false;
-    final ExampleObjectExtension other = (ExampleObjectExtension) o;
+    if (!(o instanceof ExampleObjectExtension other)) return false;
     if (!other.canEqual((Object) this)) return false;
     final Object this$valueAlways = this.getValueAlways();
     final Object other$valueAlways = other.getValueAlways();
@@ -257,8 +256,7 @@ public class ExampleObjectExtension implements ScimExtension {
 
     public boolean equals(final Object o) {
       if (o == this) return true;
-      if (!(o instanceof ComplexObject)) return false;
-      final ComplexObject other = (ComplexObject) o;
+      if (!(o instanceof ComplexObject other)) return false;
       if (!other.canEqual((Object) this)) return false;
       final Object this$value = this.getValue();
       final Object other$value = other.getValue();

--- a/scim-tools/src/test/java/org/apache/directory/scim/tools/diff/PatchGeneratorTest.java
+++ b/scim-tools/src/test/java/org/apache/directory/scim/tools/diff/PatchGeneratorTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.directory.scim.spec.resources.GroupMembership;
@@ -306,7 +305,7 @@ public class PatchGeneratorTest {
                                  .stream()
                                  .filter(e -> e.getType()
                                                .equals("work"))
-                                 .collect(Collectors.toList());
+                                 .toList();
     user2.setEmails(newEmails);
 
     List<PatchOperation> result = new PatchGenerator(schemaRegistry).diff(user1, user2);
@@ -428,7 +427,7 @@ public class PatchGeneratorTest {
     Photo photo = new Photo();
     photo.setType("photo");
     photo.setValue("photo1.png");
-    user2.setPhotos(Stream.of(photo).collect(Collectors.toList()));
+    user2.setPhotos(Stream.of(photo).toList());
 
     List<PatchOperation> operations = new PatchGenerator(schemaRegistry).diff(user1, user2);
 
@@ -870,7 +869,7 @@ public class PatchGeneratorTest {
     workAddress.setCountry("USA");
     workAddress.setPostalCode("16802");
 
-    List<Address> address = Stream.of(workAddress, homeAddress).collect(Collectors.toList());
+    List<Address> address = new ArrayList<>(List.of(workAddress, homeAddress));
     user.setAddresses(address);
 
     Email workEmail = new Email();
@@ -891,7 +890,7 @@ public class PatchGeneratorTest {
     otherEmail.setValue("outside@version.net");
     otherEmail.setDisplay("outside@version.net");
 
-    List<Email> emails = Stream.of(homeEmail, workEmail).collect(Collectors.toList());
+    List<Email> emails = new ArrayList<>(List.of(homeEmail, workEmail));
     user.setEmails(emails);
 
     //"+1(814)867-5309"
@@ -904,7 +903,7 @@ public class PatchGeneratorTest {
     workPhone.setType("work");
     workPhone.setPrimary(false);
 
-    List<PhoneNumber> phones = Stream.of(homePhone, workPhone).collect(Collectors.toList());
+    List<PhoneNumber> phones = new ArrayList<>(List.of(homePhone, workPhone));
     user.setPhoneNumbers(phones);
 
     EnterpriseExtension enterpriseExtension = new EnterpriseExtension();

--- a/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
+++ b/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 @Service
 public class InMemoryGroupService implements Repository<ScimGroup> {
@@ -135,7 +134,7 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }

--- a/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryUserService.java
+++ b/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryUserService.java
@@ -44,7 +44,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Creates a singleton (effectively) Provider<User> with a memory-based
@@ -179,7 +178,7 @@ public class InMemoryUserService implements Repository<ScimUser> {
       .skip(startIndex)
       .limit(count)
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
-      .collect(Collectors.toList());
+      .toList();
 
     return new FilterResponse<>(result, result.size());
   }


### PR DESCRIPTION
- **Replace .collect(Collectors.toList()) with .toList()**
- **Use pattern matching for instanceof (Java 16+)**
- **Seal FilterExpression, ValueFilterExpression, and UnresolvedTopLevel**
- **Use switch arrow syntax in BulkResourceImpl**
- **Use text block and String.join() in Schemas.java**
