### PR TITLE
Add BaseRepository abstract class for Repository implementations

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/BaseRepository.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/BaseRepository.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.core.repository;
+
+import org.apache.directory.scim.spec.exception.ResourceException;
+import org.apache.directory.scim.spec.exception.ResourceNotFoundException;
+import org.apache.directory.scim.spec.patch.PatchOperation;
+import org.apache.directory.scim.spec.resources.ScimResource;
+
+import java.util.List;
+
+/**
+ * Optional base class for {@link Repository} implementations that provides default
+ * implementations for common boilerplate methods.
+ *
+ * <p>Subclasses must implement {@link #create}, {@link #update}, {@link #get},
+ * {@link #find}, and {@link #delete}. The following are provided automatically:</p>
+ * <ul>
+ *   <li>{@link #getResourceClass()} — returns the class passed to the constructor</li>
+ *   <li>{@link #patch(String, List, ScimRequestContext)} — fetches the current resource
+ *       via {@link #get}, applies patch operations via {@link PatchHandler}, and persists
+ *       via {@link #update}</li>
+ * </ul>
+ *
+ * <p>Usage example:</p>
+ * <pre>
+ * &#64;Named
+ * &#64;ApplicationScoped
+ * public class MyUserRepository extends BaseRepository&lt;ScimUser&gt; {
+ *   &#64;Inject
+ *   public MyUserRepository(PatchHandler patchHandler) {
+ *     super(ScimUser.class, patchHandler);
+ *   }
+ *   // implement create, update, get, find, delete
+ * }
+ * </pre>
+ *
+ * @param <T> the SCIM resource type this repository manages
+ */
+public abstract class BaseRepository<T extends ScimResource> implements Repository<T> {
+
+  private final Class<T> resourceClass;
+  private final PatchHandler patchHandler;
+
+  /**
+   * Creates a new base repository.
+   *
+   * @param resourceClass the SCIM resource class this repository manages
+   * @param patchHandler  the handler used to apply SCIM PATCH operations
+   */
+  protected BaseRepository(Class<T> resourceClass, PatchHandler patchHandler) {
+    this.resourceClass = resourceClass;
+    this.patchHandler = patchHandler;
+  }
+
+  /**
+   * No-arg constructor for CDI proxy creation. Subclasses using CDI must also
+   * provide a no-arg constructor that calls {@code super()}.
+   */
+  protected BaseRepository() {
+    this.resourceClass = null;
+    this.patchHandler = null;
+  }
+
+  @Override
+  public Class<T> getResourceClass() {
+    return resourceClass;
+  }
+
+  /**
+   * Default PATCH implementation: fetches the current resource, applies the patch
+   * operations, and persists the result via {@link #update}.
+   *
+   * <p>Subclasses may override this method if their backend supports more efficient
+   * partial-update semantics.</p>
+   *
+   * {@inheritDoc}
+   */
+  @Override
+  public T patch(String id, List<PatchOperation> patchOperations,
+      ScimRequestContext requestContext) throws ResourceException {
+    if (patchHandler == null) {
+      throw new IllegalStateException("No PatchHandler configured; patch() is not available on this instance");
+    }
+    T current = get(id, requestContext);
+    if (current == null) {
+      throw new ResourceNotFoundException(id);
+    }
+    T patched = patchHandler.apply(current, patchOperations);
+    return update(id, patched, requestContext);
+  }
+}

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/BaseRepositoryTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/BaseRepositoryTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.core.repository;
+
+import org.apache.directory.scim.spec.exception.ResourceException;
+import org.apache.directory.scim.spec.exception.ResourceNotFoundException;
+import org.apache.directory.scim.spec.filter.Filter;
+import org.apache.directory.scim.spec.filter.FilterResponse;
+import org.apache.directory.scim.spec.patch.PatchOperation;
+import org.apache.directory.scim.spec.resources.ScimUser;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BaseRepositoryTest {
+
+  /**
+   * Concrete test subclass that delegates abstract methods to mockable lambdas.
+   */
+  static class TestRepository extends BaseRepository<ScimUser> {
+
+    TestRepository(PatchHandler patchHandler) {
+      super(ScimUser.class, patchHandler);
+    }
+
+    /** No-arg constructor to verify CDI proxy path. */
+    TestRepository() {
+      super();
+    }
+
+    @Override
+    public ScimUser create(ScimUser resource, ScimRequestContext requestContext) {
+      return null;
+    }
+
+    @Override
+    public ScimUser update(String id, ScimUser resource, ScimRequestContext requestContext) {
+      return resource;
+    }
+
+    @Override
+    public ScimUser get(String id, ScimRequestContext requestContext) {
+      return null;
+    }
+
+    @Override
+    public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
+      return null;
+    }
+
+    @Override
+    public void delete(String id) {
+    }
+  }
+
+  @Test
+  void getResourceClass_returnsClassPassedToConstructor() {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = new TestRepository(patchHandler);
+
+    assertThat(repository.getResourceClass()).isEqualTo(ScimUser.class);
+  }
+
+  @Test
+  void noArgConstructor_doesNotThrow() {
+    TestRepository repository = new TestRepository();
+
+    assertThat(repository.getResourceClass()).isNull();
+  }
+
+  @Test
+  void patch_callsGetThenApplyThenUpdate() throws ResourceException {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = Mockito.spy(new TestRepository(patchHandler));
+
+    ScimUser existing = new ScimUser();
+    existing.setId("user-1");
+    ScimUser patched = new ScimUser();
+    patched.setId("user-1-patched");
+    ScimUser updated = new ScimUser();
+    updated.setId("user-1-updated");
+
+    List<PatchOperation> ops = List.of(new PatchOperation());
+    ScimRequestContext ctx = ScimRequestContext.empty();
+
+    when(repository.get("user-1", ctx)).thenReturn(existing);
+    when(patchHandler.apply(existing, ops)).thenReturn(patched);
+    when(repository.update("user-1", patched, ctx)).thenReturn(updated);
+
+    ScimUser result = repository.patch("user-1", ops, ctx);
+
+    assertThat(result).isSameAs(updated);
+    verify(repository).get("user-1", ctx);
+    verify(patchHandler).apply(existing, ops);
+    verify(repository).update("user-1", patched, ctx);
+  }
+
+  @Test
+  void patch_throwsResourceNotFoundExceptionWhenGetReturnsNull() throws ResourceException {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = Mockito.spy(new TestRepository(patchHandler));
+
+    ScimRequestContext ctx = ScimRequestContext.empty();
+    when(repository.get("missing-id", ctx)).thenReturn(null);
+
+    assertThatThrownBy(() -> repository.patch("missing-id", List.of(), ctx))
+      .isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  @Test
+  void patch_passesCorrectIdOperationsAndContext() throws ResourceException {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = Mockito.spy(new TestRepository(patchHandler));
+
+    ScimUser existing = new ScimUser();
+    ScimUser patched = new ScimUser();
+    ScimUser updated = new ScimUser();
+
+    PatchOperation op1 = new PatchOperation();
+    PatchOperation op2 = new PatchOperation();
+    List<PatchOperation> ops = List.of(op1, op2);
+    ScimRequestContext ctx = ScimRequestContext.empty();
+
+    when(repository.get("id-42", ctx)).thenReturn(existing);
+    when(patchHandler.apply(existing, ops)).thenReturn(patched);
+    when(repository.update("id-42", patched, ctx)).thenReturn(updated);
+
+    repository.patch("id-42", ops, ctx);
+
+    verify(repository).get(eq("id-42"), eq(ctx));
+    verify(patchHandler).apply(eq(existing), eq(ops));
+    verify(repository).update(eq("id-42"), eq(patched), eq(ctx));
+  }
+
+  @Test
+  void patch_returnsResultFromUpdate() throws ResourceException {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = Mockito.spy(new TestRepository(patchHandler));
+
+    ScimUser existing = new ScimUser();
+    ScimUser patched = new ScimUser();
+    ScimUser updateResult = new ScimUser();
+    updateResult.setId("final-result");
+
+    ScimRequestContext ctx = ScimRequestContext.empty();
+    when(repository.get("id-1", ctx)).thenReturn(existing);
+    when(patchHandler.apply(any(), any())).thenReturn(patched);
+    when(repository.update(any(), any(), any())).thenReturn(updateResult);
+
+    ScimUser result = repository.patch("id-1", List.of(), ctx);
+
+    assertThat(result).isSameAs(updateResult);
+    assertThat(result.getId()).isEqualTo("final-result");
+  }
+
+  @Test
+  void patch_doesNotCallUpdateWhenGetReturnsNull() throws ResourceException {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = Mockito.spy(new TestRepository(patchHandler));
+
+    ScimRequestContext ctx = ScimRequestContext.empty();
+    when(repository.get("absent", ctx)).thenReturn(null);
+
+    try {
+      repository.patch("absent", List.of(), ctx);
+    } catch (ResourceNotFoundException e) {
+      // expected
+    }
+
+    verify(repository, Mockito.never()).update(any(), any(), any());
+    verify(patchHandler, Mockito.never()).apply(any(), any());
+  }
+
+  @Test
+  void patch_doesNotCallApplyWhenGetReturnsNull() throws ResourceException {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = Mockito.spy(new TestRepository(patchHandler));
+
+    ScimRequestContext ctx = ScimRequestContext.empty();
+    when(repository.get("no-such", ctx)).thenReturn(null);
+
+    try {
+      repository.patch("no-such", List.of(), ctx);
+    } catch (ResourceNotFoundException e) {
+      // expected
+    }
+
+    verify(patchHandler, Mockito.never()).apply(any(), any());
+  }
+
+  @Test
+  void patch_nullPatchHandler_throwsIllegalStateException() {
+    TestRepository repository = Mockito.spy(new TestRepository(null));
+
+    assertThatThrownBy(() -> repository.patch("id", List.of(), ScimRequestContext.empty()))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("No PatchHandler configured");
+  }
+
+  @Test
+  void patch_patchHandlerThrowsException_propagates() throws ResourceException {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = Mockito.spy(new TestRepository(patchHandler));
+
+    ScimUser user = new ScimUser();
+    user.setId("id1");
+    ScimRequestContext ctx = ScimRequestContext.empty();
+    when(repository.get("id1", ctx)).thenReturn(user);
+    when(patchHandler.apply(any(), any())).thenThrow(new RuntimeException("patch failed"));
+
+    assertThatThrownBy(() -> repository.patch("id1", List.of(), ctx))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessage("patch failed");
+  }
+}

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
@@ -25,8 +25,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -36,7 +36,6 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
@@ -48,18 +47,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Named
 @ApplicationScoped
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryGroupService() {}
@@ -71,11 +68,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -105,16 +97,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     if (!groups.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
     groups.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
@@ -24,8 +24,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.example.jersey4.extensions.LuckyNumberExtension;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
@@ -37,11 +37,9 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -57,7 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Named
 @ApplicationScoped
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -70,12 +68,10 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryUserService() {}
@@ -112,11 +108,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
-  }
-
   /**
    * @see Repository#create(ScimResource, ScimRequestContext)
    */
@@ -142,16 +133,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     if (!users.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
     users.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
@@ -25,8 +25,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -36,7 +36,6 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
@@ -48,18 +47,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Named
 @ApplicationScoped
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryGroupService() {}
@@ -71,11 +68,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -105,16 +97,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     if (!groups.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
     groups.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
@@ -24,8 +24,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.example.jersey.extensions.LuckyNumberExtension;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
@@ -37,11 +37,9 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -57,7 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Named
 @ApplicationScoped
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -70,12 +68,10 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryUserService() {}
@@ -112,11 +108,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
-  }
-
   /**
    * @see Repository#create(ScimResource, ScimRequestContext)
    */
@@ -142,16 +133,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     if (!users.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
     users.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
@@ -25,8 +25,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -36,7 +36,6 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
@@ -48,18 +47,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Named
 @ApplicationScoped
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryGroupService() {}
@@ -71,11 +68,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -105,16 +97,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     if (!groups.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
     groups.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
@@ -24,8 +24,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.example.memory.extensions.LuckyNumberExtension;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
@@ -37,11 +37,9 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -57,7 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Named
 @ApplicationScoped
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -70,12 +68,10 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryUserService() {}
@@ -112,11 +108,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
-  }
-
   /**
    * @see Repository#create(ScimResource, ScimRequestContext)
    */
@@ -142,16 +133,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     if (!users.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
     users.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
@@ -25,8 +25,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -36,7 +36,6 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
@@ -48,18 +47,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Named
 @ApplicationScoped
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryGroupService() {}
@@ -71,11 +68,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -105,16 +97,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     if (!groups.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
     groups.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
@@ -24,8 +24,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.example.quarkus.extensions.LuckyNumberExtension;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
@@ -37,11 +37,9 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -57,7 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Named
 @ApplicationScoped
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -70,12 +68,10 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryUserService() {}
@@ -112,11 +108,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
-  }
-
   /**
    * @see Repository#create(ScimResource, ScimRequestContext)
    */
@@ -142,16 +133,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     if (!users.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
     users.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -21,8 +21,8 @@ package org.apache.directory.scim.example.spring.service;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -32,7 +32,6 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.springframework.stereotype.Service;
@@ -45,17 +44,15 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private final SchemaRegistry schemaRegistry;
 
-  private final PatchHandler patchHandler;
-
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   @PostConstruct
@@ -65,11 +62,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -99,16 +91,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     if (!groups.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
     groups.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -21,8 +21,8 @@ package org.apache.directory.scim.example.spring.service;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.example.spring.extensions.LuckyNumberExtension;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
@@ -34,11 +34,9 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.springframework.stereotype.Service;
 
@@ -54,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Chris Harm &lt;crh5255@psu.edu&gt;
  */
 @Service
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -67,11 +65,9 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private final SchemaRegistry schemaRegistry;
 
-  private final PatchHandler patchHandler;
-
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   @PostConstruct
@@ -106,11 +102,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
-  }
-
   /**
    * @see Repository#create(ScimResource, ScimRequestContext)
    */
@@ -136,16 +127,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     if (!users.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
     users.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -21,8 +21,8 @@ package org.apache.directory.scim.example.spring.service;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -32,7 +32,6 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.springframework.stereotype.Service;
@@ -45,17 +44,15 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private final SchemaRegistry schemaRegistry;
 
-  private final PatchHandler patchHandler;
-
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   @PostConstruct
@@ -65,11 +62,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -99,16 +91,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     if (!groups.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
     groups.put(id, resource);
     return resource;
   }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -21,8 +21,8 @@ package org.apache.directory.scim.example.spring.service;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.core.Response;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.example.spring.extensions.LuckyNumberExtension;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
@@ -34,11 +34,9 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
 import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.springframework.stereotype.Service;
 
@@ -54,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Chris Harm &lt;crh5255@psu.edu&gt;
  */
 @Service
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = UUID.randomUUID().toString();
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -67,11 +65,9 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private final SchemaRegistry schemaRegistry;
 
-  private final PatchHandler patchHandler;
-
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   @PostConstruct
@@ -106,11 +102,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
-  }
-
   /**
    * @see Repository#create(ScimResource, ScimRequestContext)
    */
@@ -136,16 +127,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     if (!users.containsKey(id)) {
       throw new ResourceNotFoundException(id);
     }
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
     users.put(id, resource);
     return resource;
   }


### PR DESCRIPTION
Provides default implementations for getResourceClass() and patch(),
eliminating boilerplate that every Repository implementation must
repeat. The patch() default uses the standard get-apply-update pattern
with PatchHandler. Subclasses only need to implement create, update,
get, find, and delete.

Generated-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>