### PR TITLE
Add pagination helpers to PageRequest and javadoc to FilterResponse

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/ScimRequestContext.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/ScimRequestContext.java
@@ -99,6 +99,15 @@ public class ScimRequestContext {
     return Optional.ofNullable(pageRequest);
   }
 
+  /**
+   * Returns the page request, defaulting to an unbounded request if none was specified.
+   *
+   * @return the page request; never null
+   */
+  public PageRequest getPageRequestOrDefault() {
+    return pageRequest != null ? pageRequest : new PageRequest();
+  }
+
   public ScimRequestContext setPageRequest(PageRequest pageRequest) {
     this.pageRequest = pageRequest;
     return this;

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
@@ -115,16 +115,12 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
@@ -108,9 +108,6 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String id = UUID.randomUUID().toString();
@@ -137,17 +134,11 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(java.lang.String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(java.lang.String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -155,26 +146,16 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
@@ -115,16 +115,12 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
@@ -108,9 +108,6 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String id = UUID.randomUUID().toString();
@@ -137,17 +134,11 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(java.lang.String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(java.lang.String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -155,26 +146,16 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
@@ -115,16 +115,12 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
@@ -108,9 +108,6 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String id = UUID.randomUUID().toString();
@@ -137,17 +134,11 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(java.lang.String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(java.lang.String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -155,26 +146,16 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
@@ -115,16 +115,12 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
@@ -108,9 +108,6 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String id = UUID.randomUUID().toString();
@@ -137,17 +134,11 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(java.lang.String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(java.lang.String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -155,26 +146,16 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -109,16 +109,12 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -102,9 +102,6 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String id = UUID.randomUUID().toString();
@@ -131,17 +128,11 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(java.lang.String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(java.lang.String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -149,26 +140,16 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -109,16 +109,12 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -102,9 +102,6 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     users.put(user.getId(), user);
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String id = UUID.randomUUID().toString();
@@ -131,17 +128,11 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(java.lang.String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(java.lang.String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -149,26 +140,16 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
@@ -133,16 +133,12 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
@@ -104,9 +104,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     return ScimUser.class;
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String resourceId = resource.getId();
@@ -150,17 +147,11 @@ public class InMemoryUserService implements Repository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -168,26 +159,16 @@ public class InMemoryUserService implements Repository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return List.of(LuckyNumberExtension.class);

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/FilterResponse.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/FilterResponse.java
@@ -21,13 +21,39 @@ package org.apache.directory.scim.spec.filter;
 
 import java.util.Collection;
 
+/**
+ * Holds the result of a {@link org.apache.directory.scim.core.repository.Repository#find Repository.find()}
+ * query, including the paginated resources and the total count of matching resources.
+ *
+ * <p><b>Important:</b> {@code totalResults} must be the total number of resources matching
+ * the query <em>before</em> pagination is applied, not the number of resources in this page.
+ * This allows SCIM clients to calculate how many pages exist. See
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.4">RFC 7644 §3.4.2.4</a>.</p>
+ *
+ * <p>Example: if 50 users match a filter and the client requests {@code startIndex=11&count=10},
+ * then {@code resources} contains 10 users and {@code totalResults} is 50.</p>
+ *
+ * @param <T> the resource type
+ */
 public class FilterResponse<T> {
-  
+
   private Collection<T> resources;
+
+  /**
+   * The total number of resources matching the query, before pagination.
+   * This is NOT the size of the {@link #resources} collection (which is the page size).
+   */
   private int totalResults;
-  
+
   public FilterResponse() {}
-  
+
+  /**
+   * Creates a filter response with the given page of resources and total count.
+   *
+   * @param resources    the resources in this page (may be a subset of all matching resources)
+   * @param totalResults the total number of matching resources <em>before</em> pagination —
+   *                     must be {@code >= resources.size()}
+   */
   public FilterResponse(Collection<T> resources, int totalResults) {
     this.resources = resources;
     this.totalResults = totalResults;

--- a/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/PageRequest.java
+++ b/scim-spec/scim-spec-schema/src/main/java/org/apache/directory/scim/spec/filter/PageRequest.java
@@ -19,6 +19,8 @@
 
 package org.apache.directory.scim.spec.filter;
 
+import java.util.List;
+
 public class PageRequest {
   private Integer startIndex;
   private Integer count;
@@ -66,6 +68,55 @@ public class PageRequest {
     final Object $count = this.getCount();
     result = result * PRIME + ($count == null ? 43 : $count.hashCode());
     return result;
+  }
+
+  /**
+   * Converts the 1-based SCIM {@code startIndex} to a 0-based offset suitable for
+   * Java stream {@code skip()} or list {@code subList()} operations.
+   *
+   * <p>SCIM uses 1-based indexing: {@code startIndex=1} means the first result.
+   * Per <a href="https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.4">RFC 7644 §3.4.2.4</a>,
+   * a value less than 1 is interpreted as 1 (offset 0). Returns 0 if
+   * {@code startIndex} is null.</p>
+   *
+   * @return the 0-based offset (always {@code >= 0})
+   */
+  public long getZeroBasedStartIndex() {
+    return startIndex != null ? Math.max(0, startIndex - 1L) : 0L;
+  }
+
+  /**
+   * Returns the effective page size, defaulting to {@code totalResults} if the
+   * client did not specify a {@code count} parameter.
+   *
+   * <p>Per <a href="https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.4">RFC 7644 §3.4.2.4</a>,
+   * a {@code count} of 0 means "return no resources" (only {@code totalResults}),
+   * and a negative value is interpreted as 0.</p>
+   *
+   * @param totalResults the total number of matching resources (before pagination)
+   * @return the effective page size (always {@code >= 0})
+   */
+  public long getEffectiveCount(int totalResults) {
+    if (count == null) {
+      return (long) totalResults;
+    }
+    return Math.max(0L, count.longValue());
+  }
+
+  /**
+   * Returns the sublist of {@code items} corresponding to this page.
+   *
+   * <p>Applies {@link #getZeroBasedStartIndex()} and {@link #getEffectiveCount(int)}
+   * to produce the correct window, clamping to list bounds.</p>
+   *
+   * @param items the full list of matching results (before pagination)
+   * @param <T>   the element type
+   * @return the page slice; never null
+   */
+  public <T> List<T> paginate(List<T> items) {
+    int from = (int) Math.min(getZeroBasedStartIndex(), items.size());
+    int to = (int) Math.min(from + getEffectiveCount(items.size()), items.size());
+    return items.subList(from, to);
   }
 
   public String toString() {

--- a/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/filter/PageRequestTest.java
+++ b/scim-spec/scim-spec-schema/src/test/java/org/apache/directory/scim/spec/filter/PageRequestTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.scim.spec.filter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PageRequestTest {
+
+  @Test
+  void getZeroBasedStartIndex_withStartIndex1_returns0() {
+    PageRequest pageRequest = new PageRequest().setStartIndex(1);
+
+    assertThat(pageRequest.getZeroBasedStartIndex()).isEqualTo(0L);
+  }
+
+  @Test
+  void getZeroBasedStartIndex_withStartIndex5_returns4() {
+    PageRequest pageRequest = new PageRequest().setStartIndex(5);
+
+    assertThat(pageRequest.getZeroBasedStartIndex()).isEqualTo(4L);
+  }
+
+  @Test
+  void getZeroBasedStartIndex_withNullStartIndex_returns0() {
+    PageRequest pageRequest = new PageRequest();
+
+    assertThat(pageRequest.getZeroBasedStartIndex()).isEqualTo(0L);
+  }
+
+  @Test
+  void getZeroBasedStartIndex_withStartIndex0_returns0_clamped() {
+    PageRequest pageRequest = new PageRequest().setStartIndex(0);
+
+    assertThat(pageRequest.getZeroBasedStartIndex()).isEqualTo(0L);
+  }
+
+  @Test
+  void getEffectiveCount_withCount10_andTotalResults50_returns10() {
+    PageRequest pageRequest = new PageRequest().setCount(10);
+
+    assertThat(pageRequest.getEffectiveCount(50)).isEqualTo(10L);
+  }
+
+  @Test
+  void getEffectiveCount_withNullCount_andTotalResults50_returns50() {
+    PageRequest pageRequest = new PageRequest();
+
+    assertThat(pageRequest.getEffectiveCount(50)).isEqualTo(50L);
+  }
+
+  @Test
+  void getEffectiveCount_withCount0_returns0() {
+    // RFC 7644 §3.4.2.4: count=0 means "return no resources"
+    PageRequest pageRequest = new PageRequest().setCount(0);
+
+    assertThat(pageRequest.getEffectiveCount(50)).isEqualTo(0L);
+  }
+
+  @Test
+  void getEffectiveCount_withNegativeCount_returns0() {
+    // RFC 7644 §3.4.2.4: negative count interpreted as 0
+    PageRequest pageRequest = new PageRequest().setCount(-1);
+
+    assertThat(pageRequest.getEffectiveCount(50)).isEqualTo(0L);
+  }
+
+  @Test
+  void paginate_returnsCorrectPage() {
+    List<String> items = List.of("a", "b", "c", "d", "e");
+    PageRequest pageRequest = new PageRequest().setStartIndex(2).setCount(2);
+
+    assertThat(pageRequest.paginate(items)).containsExactly("b", "c");
+  }
+
+  @Test
+  void paginate_withDefaults_returnsAll() {
+    List<String> items = List.of("a", "b", "c");
+    PageRequest pageRequest = new PageRequest();
+
+    assertThat(pageRequest.paginate(items)).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  void paginate_withStartBeyondSize_returnsEmpty() {
+    List<String> items = List.of("a", "b");
+    PageRequest pageRequest = new PageRequest().setStartIndex(10).setCount(5);
+
+    assertThat(pageRequest.paginate(items)).isEmpty();
+  }
+
+  @Test
+  void paginate_withCountBeyondRemaining_returnsTail() {
+    List<String> items = List.of("a", "b", "c", "d", "e");
+    PageRequest pageRequest = new PageRequest().setStartIndex(4).setCount(10);
+
+    assertThat(pageRequest.paginate(items)).containsExactly("d", "e");
+  }
+
+  @Test
+  void paginate_withEmptyList_returnsEmpty() {
+    PageRequest pageRequest = new PageRequest().setStartIndex(1).setCount(10);
+
+    assertThat(pageRequest.paginate(List.of())).isEmpty();
+  }
+}

--- a/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
+++ b/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
@@ -127,16 +127,12 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
 
   @Override
   public FilterResponse<ScimGroup> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(groups.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimGroup> result = groups.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimGroup> filtered = groups.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimGroup.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
   @Override

--- a/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryUserService.java
+++ b/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryUserService.java
@@ -102,9 +102,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     return ScimUser.class;
   }
 
-  /**
-   * @see Repository#create(ScimResource, ScimRequestContext)
-   */
   @Override
   public ScimUser create(ScimUser resource, ScimRequestContext requestContext) throws UnableToCreateResourceException {
     String resourceId = resource.getId();
@@ -148,17 +145,11 @@ public class InMemoryUserService implements Repository<ScimUser> {
     return resource;
   }
 
-  /**
-   * @see Repository#get(String, ScimRequestContext)
-   */
   @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
 
-  /**
-   * @see Repository#delete(String)
-   */
   @Override
   public void delete(String id) throws ResourceException {
     if (users.remove(id) == null) {
@@ -166,26 +157,16 @@ public class InMemoryUserService implements Repository<ScimUser> {
     }
   }
 
-  /**
-   * @see Repository#find(Filter, ScimRequestContext)
-   */
   @Override
   public FilterResponse<ScimUser> find(Filter filter, ScimRequestContext requestContext) {
-    long count = requestContext.getPageRequest().map(PageRequest::getCount).orElse(users.size());
-    long startIndex = requestContext.getPageRequest().map(PageRequest::getStartIndex).map(it -> it - 1).orElse(0);
-
-    List<ScimUser> result = users.values().stream()
-      .skip(startIndex)
-      .limit(count)
+    List<ScimUser> filtered = users.values().stream()
       .filter(FilterExpressions.inMemory(filter, schemaRegistry.getSchema(ScimUser.SCHEMA_URI)))
       .toList();
 
-    return new FilterResponse<>(result, result.size());
+    PageRequest pageRequest = requestContext.getPageRequestOrDefault();
+    return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  /**
-   * @see Repository#getExtensionList()
-   */
   @Override
   public List<Class<? extends ScimExtension>> getExtensionList() {
     return Collections.emptyList();


### PR DESCRIPTION
PageRequest gains getZeroBasedStartIndex() and getEffectiveCount(int)
to eliminate the error-prone 1-based to 0-based conversion that every
Repository implementation must duplicate.

FilterResponse gets javadoc clarifying that totalResults must be the
total count of ALL matching resources before pagination, not the page
size. References RFC 7644 §3.4.2.4.

Generated-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>