### PR TITLE
Move getExtensionList() into BaseRepository as constructor parameter

### DIFF
--- a/scim-core/src/main/java/org/apache/directory/scim/core/repository/BaseRepository.java
+++ b/scim-core/src/main/java/org/apache/directory/scim/core/repository/BaseRepository.java
@@ -22,6 +22,7 @@ package org.apache.directory.scim.core.repository;
 import org.apache.directory.scim.spec.exception.ResourceException;
 import org.apache.directory.scim.spec.exception.ResourceNotFoundException;
 import org.apache.directory.scim.spec.patch.PatchOperation;
+import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimResource;
 
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.List;
  * {@link #find}, and {@link #delete}. The following are provided automatically:</p>
  * <ul>
  *   <li>{@link #getResourceClass()} — returns the class passed to the constructor</li>
+ *   <li>{@link #getExtensionList()} — returns the extension classes passed to the constructor</li>
  *   <li>{@link #patch(String, List, ScimRequestContext)} — fetches the current resource
  *       via {@link #get}, applies patch operations via {@link PatchHandler}, and persists
  *       via {@link #update}</li>
@@ -46,7 +48,7 @@ import java.util.List;
  * public class MyUserRepository extends BaseRepository&lt;ScimUser&gt; {
  *   &#64;Inject
  *   public MyUserRepository(PatchHandler patchHandler) {
- *     super(ScimUser.class, patchHandler);
+ *     super(ScimUser.class, patchHandler, MyExtension.class);
  *   }
  *   // implement create, update, get, find, delete
  * }
@@ -58,16 +60,21 @@ public abstract class BaseRepository<T extends ScimResource> implements Reposito
 
   private final Class<T> resourceClass;
   private final PatchHandler patchHandler;
+  private final List<Class<? extends ScimExtension>> extensionList;
 
   /**
    * Creates a new base repository.
    *
    * @param resourceClass the SCIM resource class this repository manages
    * @param patchHandler  the handler used to apply SCIM PATCH operations
+   * @param extensions    SCIM extension classes supported by this repository (may be empty)
    */
-  protected BaseRepository(Class<T> resourceClass, PatchHandler patchHandler) {
+  @SafeVarargs
+  protected BaseRepository(Class<T> resourceClass, PatchHandler patchHandler,
+      Class<? extends ScimExtension>... extensions) {
     this.resourceClass = resourceClass;
     this.patchHandler = patchHandler;
+    this.extensionList = extensions != null ? List.of(extensions) : List.of();
   }
 
   /**
@@ -77,11 +84,17 @@ public abstract class BaseRepository<T extends ScimResource> implements Reposito
   protected BaseRepository() {
     this.resourceClass = null;
     this.patchHandler = null;
+    this.extensionList = List.of();
   }
 
   @Override
   public Class<T> getResourceClass() {
     return resourceClass;
+  }
+
+  @Override
+  public List<Class<? extends ScimExtension>> getExtensionList() {
+    return extensionList;
   }
 
   /**

--- a/scim-core/src/test/java/org/apache/directory/scim/core/repository/BaseRepositoryTest.java
+++ b/scim-core/src/test/java/org/apache/directory/scim/core/repository/BaseRepositoryTest.java
@@ -24,6 +24,7 @@ import org.apache.directory.scim.spec.exception.ResourceNotFoundException;
 import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.patch.PatchOperation;
+import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -46,6 +47,11 @@ class BaseRepositoryTest {
 
     TestRepository(PatchHandler patchHandler) {
       super(ScimUser.class, patchHandler);
+    }
+
+    @SafeVarargs
+    TestRepository(PatchHandler patchHandler, Class<? extends ScimExtension>... extensions) {
+      super(ScimUser.class, patchHandler, extensions);
     }
 
     /** No-arg constructor to verify CDI proxy path. */
@@ -237,4 +243,32 @@ class BaseRepositoryTest {
       .isInstanceOf(RuntimeException.class)
       .hasMessage("patch failed");
   }
+
+  @Test
+  void getExtensionList_defaultsToEmptyList() {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = new TestRepository(patchHandler);
+
+    assertThat(repository.getExtensionList()).isEmpty();
+  }
+
+  @Test
+  void getExtensionList_returnsProvidedExtensions() {
+    PatchHandler patchHandler = Mockito.mock(PatchHandler.class);
+    TestRepository repository = new TestRepository(patchHandler, ExtensionA.class, ExtensionB.class);
+
+    assertThat(repository.getExtensionList())
+      .containsExactly(ExtensionA.class, ExtensionB.class);
+  }
+
+  @Test
+  void getExtensionList_noArgConstructor_returnsEmptyList() {
+    TestRepository repository = new TestRepository();
+
+    assertThat(repository.getExtensionList()).isEmpty();
+  }
+
+  /** Stub extension types for testing. */
+  static abstract class ExtensionA implements ScimExtension {}
+  static abstract class ExtensionB implements ScimExtension {}
 }

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryGroupService.java
@@ -36,10 +36,8 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -121,11 +119,6 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey-4/src/main/java/org/apache/directory/scim/example/jersey4/service/InMemoryUserService.java
@@ -39,7 +39,6 @@ import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -70,7 +69,7 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
-    super(ScimUser.class, patchHandler);
+    super(ScimUser.class, patchHandler, LuckyNumberExtension.class, EnterpriseExtension.class);
     this.schemaRegistry = schemaRegistry;
   }
 
@@ -156,8 +155,4 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);
-  }
 }

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryGroupService.java
@@ -36,10 +36,8 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -121,11 +119,6 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-jersey/src/main/java/org/apache/directory/scim/example/jersey/service/InMemoryUserService.java
@@ -39,7 +39,6 @@ import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -70,7 +69,7 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
-    super(ScimUser.class, patchHandler);
+    super(ScimUser.class, patchHandler, LuckyNumberExtension.class, EnterpriseExtension.class);
     this.schemaRegistry = schemaRegistry;
   }
 
@@ -156,8 +155,4 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);
-  }
 }

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryGroupService.java
@@ -36,10 +36,8 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -121,11 +119,6 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-memory/src/main/java/org/apache/directory/scim/example/memory/service/InMemoryUserService.java
@@ -39,7 +39,6 @@ import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -70,7 +69,7 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
-    super(ScimUser.class, patchHandler);
+    super(ScimUser.class, patchHandler, LuckyNumberExtension.class, EnterpriseExtension.class);
     this.schemaRegistry = schemaRegistry;
   }
 
@@ -156,8 +155,4 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);
-  }
 }

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryGroupService.java
@@ -36,10 +36,8 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -121,11 +119,6 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-quarkus/src/main/java/org/apache/directory/scim/example/quarkus/service/InMemoryUserService.java
@@ -39,7 +39,6 @@ import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -70,7 +69,7 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
-    super(ScimUser.class, patchHandler);
+    super(ScimUser.class, patchHandler, LuckyNumberExtension.class, EnterpriseExtension.class);
     this.schemaRegistry = schemaRegistry;
   }
 
@@ -156,8 +155,4 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);
-  }
 }

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -32,12 +32,10 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -115,11 +113,6 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot-4/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -36,7 +36,6 @@ import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.springframework.stereotype.Service;
 
@@ -66,7 +65,7 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
   private final SchemaRegistry schemaRegistry;
 
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
-    super(ScimUser.class, patchHandler);
+    super(ScimUser.class, patchHandler, LuckyNumberExtension.class, EnterpriseExtension.class);
     this.schemaRegistry = schemaRegistry;
   }
 
@@ -150,8 +149,4 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);
-  }
 }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryGroupService.java
@@ -32,12 +32,10 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -115,11 +113,6 @@ public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
+++ b/scim-server-examples/scim-server-spring-boot/src/main/java/org/apache/directory/scim/example/spring/service/InMemoryUserService.java
@@ -36,7 +36,6 @@ import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.springframework.stereotype.Service;
 
@@ -66,7 +65,7 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
   private final SchemaRegistry schemaRegistry;
 
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
-    super(ScimUser.class, patchHandler);
+    super(ScimUser.class, patchHandler, LuckyNumberExtension.class, EnterpriseExtension.class);
     this.schemaRegistry = schemaRegistry;
   }
 
@@ -150,8 +149,4 @@ public class InMemoryUserService extends BaseRepository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return List.of(LuckyNumberExtension.class, EnterpriseExtension.class);
-  }
 }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryGroupService.java
@@ -26,7 +26,7 @@ import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -36,11 +36,8 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -48,18 +45,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Named
 @ApplicationScoped
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryGroupService() {}
@@ -71,11 +66,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -110,16 +100,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
   }
 
   @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
   public ScimGroup get(String id, ScimRequestContext requestContext) {
     return groups.get(id);
   }
@@ -139,11 +119,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
+++ b/scim-server/src/test/java/org/apache/directory/scim/server/it/testapp/InMemoryUserService.java
@@ -25,7 +25,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -35,11 +35,8 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 
 import java.util.List;
@@ -54,7 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Named
 @ApplicationScoped
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = "1";
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -67,12 +64,10 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private SchemaRegistry schemaRegistry;
 
-  private PatchHandler patchHandler;
-
   @Inject
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler, LuckyNumberExtension.class);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   protected InMemoryUserService() {}
@@ -97,11 +92,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
     user.addExtension(new LuckyNumberExtension().setLuckyNumber(DEFAULT_USER_LUCKY_NUMBER));
 
     users.put(user.getId(), user);
-  }
-
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
   }
 
   @Override
@@ -138,16 +128,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
   }
 
   @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
@@ -169,8 +149,4 @@ public class InMemoryUserService implements Repository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return List.of(LuckyNumberExtension.class);
-  }
 }

--- a/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
+++ b/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryGroupService.java
@@ -23,7 +23,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -33,29 +33,24 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
-import org.apache.directory.scim.spec.resources.ScimExtension;
 import org.apache.directory.scim.spec.resources.ScimGroup;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
-public class InMemoryGroupService implements Repository<ScimGroup> {
+public class InMemoryGroupService extends BaseRepository<ScimGroup> {
 
   private final Map<String, ScimGroup> groups = new ConcurrentHashMap<>();
 
   private final SchemaRegistry schemaRegistry;
 
-  private final PatchHandler patchHandler;
-
   public InMemoryGroupService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimGroup.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   @PostConstruct
@@ -65,11 +60,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
     group.setDisplayName("example-group");
     group.setExternalId("example-group");
     groups.put(group.getId(), group);
-  }
-
-  @Override
-  public Class<ScimGroup> getResourceClass() {
-    return ScimGroup.class;
   }
 
   @Override
@@ -104,16 +94,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
   }
 
   @Override
-  public ScimGroup patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!groups.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimGroup resource = patchHandler.apply(get(id, requestContext), patchOperations);
-    groups.put(id, resource);
-    return resource;
-  }
-
-  @Override
   public ScimGroup get(String id, ScimRequestContext requestContext) {
     return groups.get(id);
   }
@@ -133,11 +113,6 @@ public class InMemoryGroupService implements Repository<ScimGroup> {
 
     PageRequest pageRequest = requestContext.getPageRequestOrDefault();
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
-  }
-
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
   }
 
 }

--- a/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryUserService.java
+++ b/support/spring-boot/src/test/java/org/apache/directory/scim/spring/it/app/InMemoryUserService.java
@@ -22,7 +22,7 @@ package org.apache.directory.scim.spring.it.app;
 import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.core.Response;
 import org.apache.directory.scim.core.repository.PatchHandler;
-import org.apache.directory.scim.core.repository.Repository;
+import org.apache.directory.scim.core.repository.BaseRepository;
 import org.apache.directory.scim.core.schema.SchemaRegistry;
 import org.apache.directory.scim.server.exception.UnableToCreateResourceException;
 import org.apache.directory.scim.core.repository.ScimRequestContext;
@@ -32,15 +32,11 @@ import org.apache.directory.scim.spec.filter.Filter;
 import org.apache.directory.scim.spec.filter.FilterExpressions;
 import org.apache.directory.scim.spec.filter.FilterResponse;
 import org.apache.directory.scim.spec.filter.PageRequest;
-import org.apache.directory.scim.spec.patch.PatchOperation;
 import org.apache.directory.scim.spec.resources.Email;
 import org.apache.directory.scim.spec.resources.Name;
-import org.apache.directory.scim.spec.resources.ScimExtension;
-import org.apache.directory.scim.spec.resources.ScimResource;
 import org.apache.directory.scim.spec.resources.ScimUser;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,7 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Chris Harm &lt;crh5255@psu.edu&gt;
  */
 @Service
-public class InMemoryUserService implements Repository<ScimUser> {
+public class InMemoryUserService extends BaseRepository<ScimUser> {
 
   static final String DEFAULT_USER_ID = "1";
   static final String DEFAULT_USER_EXTERNAL_ID = "e" + DEFAULT_USER_ID;
@@ -65,11 +61,9 @@ public class InMemoryUserService implements Repository<ScimUser> {
 
   private final SchemaRegistry schemaRegistry;
 
-  private final PatchHandler patchHandler;
-
   public InMemoryUserService(SchemaRegistry schemaRegistry, PatchHandler patchHandler) {
+    super(ScimUser.class, patchHandler);
     this.schemaRegistry = schemaRegistry;
-    this.patchHandler = patchHandler;
   }
 
   @PostConstruct
@@ -95,11 +89,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
 //    user.addExtension(luckyNumberExtension);
     
     users.put(user.getId(), user);
-  }
-
-  @Override
-  public Class<ScimUser> getResourceClass() {
-    return ScimUser.class;
   }
 
   @Override
@@ -136,16 +125,6 @@ public class InMemoryUserService implements Repository<ScimUser> {
   }
 
   @Override
-  public ScimUser patch(String id, List<PatchOperation> patchOperations, ScimRequestContext requestContext) throws ResourceException {
-    if (!users.containsKey(id)) {
-      throw new ResourceNotFoundException(id);
-    }
-    ScimUser resource = patchHandler.apply(get(id, requestContext), patchOperations);
-    users.put(id, resource);
-    return resource;
-  }
-
-  @Override
   public ScimUser get(String id, ScimRequestContext requestContext) {
     return users.get(id);
   }
@@ -167,8 +146,4 @@ public class InMemoryUserService implements Repository<ScimUser> {
     return new FilterResponse<>(pageRequest.paginate(filtered), filtered.size());
   }
 
-  @Override
-  public List<Class<? extends ScimExtension>> getExtensionList() {
-    return Collections.emptyList();
-  }
 }


### PR DESCRIPTION
## Summary
- Extension classes are now passed to the `BaseRepository` constructor as varargs, removing the need for each subclass to override `getExtensionList()`
- Repositories with no extensions simply omit the parameter (defaults to empty list)
- Migrates `scim-server` and `spring-boot` test InMemory services from raw `Repository` to `BaseRepository`, removing duplicate `patch()` and `getResourceClass()` implementations

## Test plan
- [x] `BaseRepositoryTest` has 3 new tests for extension list behavior (default empty, provided extensions, no-arg constructor)
- [x] Full `mvn clean verify` passes