### PR TITLE
Only run compilation in CodeQL CI job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Maven Build
         run: |
-          ./mvnw verify pmd:aggregate-pmd -Pci \
+          ./mvnw compile test-compile pmd:aggregate-pmd -Pci \
             -Ddevelocity.cache.local.enabled=false \
             -Ddevelocity.cache.remote.enabled=false
 


### PR DESCRIPTION
A full build is run in other jobs, this will speed up the slow CodeQL process
