### PR TITLE
Add SECURITY.md + AGENTS.md linking the Apache Directory umbrella threat model for discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Licensed to the Apache Software Foundation (ASF) under the Apache License, Version 2.0.
+See the umbrella threat model and SECURITY.md for security guidance.
+-->
+
+# Agent Guide for directory-scimple
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md) -> the Apache Directory umbrella threat
+model at https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md
+
+This repository is a SCIM 2.0 provisioning implementation. Agents scanning it should consult the umbrella threat
+model (SCIM addendum (S)) before reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Apache Directory follows the [ASF security process](https://www.apache.org/security/). Report privately to
+`security@apache.org` (PMC: `private@directory.apache.org`); do not open public issues/PRs for security reports.
+
+## Threat Model
+
+`apache/directory-scimple` is a SCIM 2.0 provisioning implementation within the Apache Directory project. Its security context is covered by the Apache
+Directory umbrella threat model (SCIM addendum (S)): https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md


### PR DESCRIPTION
This is a proposal for the Directory PMC to review. apache/directory-scimple is a SCIM 2.0 provisioning implementation; this PR adds a SECURITY.md and AGENTS.md so an automated scan agent can discover the project's security model via AGENTS.md -> SECURITY.md -> the Apache Directory umbrella threat model (https://github.com/apache/directory-server/blob/master/THREAT_MODEL.md, SCIM addendum (S)). Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting. Questions/pushback welcome.