### PR TITLE
Prevent example modules from being published to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,7 @@
     <module>scim-client</module>
     <module>scim-core</module>
     <module>scim-server</module>
-    <module>scim-server-examples/scim-server-memory</module>
-    <module>scim-server-examples/scim-server-jersey</module>
-    <module>scim-server-examples/scim-server-jersey-4</module>
-    <module>scim-server-examples/scim-server-quarkus</module>
-    <module>scim-server-examples/scim-server-spring-boot</module>
-    <module>scim-server-examples/scim-server-spring-boot-4</module>
+    <module>scim-server-examples</module>
     <module>support/spring-boot</module>
     <module>scim-tools</module>
     <module>scim-compliance-tests</module>

--- a/scim-server-examples/pom.xml
+++ b/scim-server-examples/pom.xml
@@ -1,0 +1,80 @@
+<!--  Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.directory.scimple</groupId>
+    <artifactId>scimple</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.apache.directory.scimple.examples</groupId>
+  <artifactId>scim-server-examples</artifactId>
+  <name>SCIMple - Server - Examples</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+  </properties>
+
+  <modules>
+    <module>scim-server-memory</module>
+    <module>scim-server-jersey</module>
+    <module>scim-server-jersey-4</module>
+    <module>scim-server-quarkus</module>
+    <module>scim-server-spring-boot</module>
+    <module>scim-server-spring-boot-4</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <configuration>
+            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/scim-server-examples/scim-server-jersey-4/pom.xml
+++ b/scim-server-examples/scim-server-jersey-4/pom.xml
@@ -18,10 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scimple</artifactId>
+    <groupId>org.apache.directory.scimple.examples</groupId>
+    <artifactId>scim-server-examples</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-jersey-4</artifactId>

--- a/scim-server-examples/scim-server-jersey/pom.xml
+++ b/scim-server-examples/scim-server-jersey/pom.xml
@@ -18,10 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scimple</artifactId>
+    <groupId>org.apache.directory.scimple.examples</groupId>
+    <artifactId>scim-server-examples</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-jersey</artifactId>

--- a/scim-server-examples/scim-server-memory/pom.xml
+++ b/scim-server-examples/scim-server-memory/pom.xml
@@ -18,10 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scimple</artifactId>
+    <groupId>org.apache.directory.scimple.examples</groupId>
+    <artifactId>scim-server-examples</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-memory</artifactId>

--- a/scim-server-examples/scim-server-quarkus/pom.xml
+++ b/scim-server-examples/scim-server-quarkus/pom.xml
@@ -18,10 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scimple</artifactId>
+    <groupId>org.apache.directory.scimple.examples</groupId>
+    <artifactId>scim-server-examples</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-quarkus</artifactId>

--- a/scim-server-examples/scim-server-spring-boot-4/pom.xml
+++ b/scim-server-examples/scim-server-spring-boot-4/pom.xml
@@ -18,10 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scimple</artifactId>
+    <groupId>org.apache.directory.scimple.examples</groupId>
+    <artifactId>scim-server-examples</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-spring-boot4</artifactId>

--- a/scim-server-examples/scim-server-spring-boot/pom.xml
+++ b/scim-server-examples/scim-server-spring-boot/pom.xml
@@ -18,10 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.directory.scimple</groupId>
-    <artifactId>scimple</artifactId>
+    <groupId>org.apache.directory.scimple.examples</groupId>
+    <artifactId>scim-server-examples</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>scim-server-spring-boot</artifactId>


### PR DESCRIPTION
## What

Introduce an intermediate parent POM at `scim-server-examples/pom.xml` (groupId `org.apache.directory.scimple.examples`, `packaging=pom`) that makes the example modules non-publishing, and reparent the six examples under it.

## Why

The `scim-server-examples/*` demos are intentionally **not** production-hardened (cleartext passwords, no auth/TLS). They are documented as out of scope and "not published to Maven Central", but nothing in the build actually enforced that — a full reactor `deploy` would have staged them. This makes that guarantee structural rather than aspirational.

## How

- New `scim-server-examples/pom.xml` sets `maven.deploy.skip` and `skipNexusStagingDeployMojo` once, plus an `apache-release` profile that skips the source, gpg, and javadoc plugins for the examples.
- The six example modules inherit from it, so **future** example modules are non-publishing by default.
- The root reactor now lists the single `scim-server-examples` aggregator instead of the six individual modules.
- **`scim-coverage` is deliberately left untouched.** It is the last reactor module, which is where `nexus-staging-maven-plugin` triggers the deferred batch upload — skipping it would suppress publishing of the real libraries. A comment marks it as required-last.

The set of published modules (`scim-spec-schema`, `scim-spec-protocol`, `scim-client`, `scim-core`, `scim-server`, `scim-spring-boot-starter`, and the test-support artifacts) is unchanged.

## Verification

Local, `-Pci`:

- `./mvnw -Pci -DskipTests verify` — BUILD SUCCESS across all modules (RAT + SpotBugs clean).
- During a full-reactor deploy, each of the six examples logs `Skipping Nexus Staging Deploy Mojo at user's demand.`, while `scim-core` and `scim-server` perform deferred deploys — confirming the skip does **not** leak to the published libraries.

> Note: a local file-repo deploy cannot exercise the real Nexus staging path (nexus-staging with `extensions=true` ignores `-DaltDeploymentRepository` and contacts `repository.apache.org` at reactor close). A maintainer with ASF staging credentials should confirm a real staging run shows the examples absent and the libraries present before the next release.
