### PR TITLE
Run GlassFish integration tests against 7.x and 8.x

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,16 @@
   // Max 10 PRs in total, 10 per hour
   prConcurrentLimit: 10,
   prHourlyLimit: 10,
+  packageRules: [
+    {
+      // Keep the GlassFish 7.x line on the 7 series; the 8.x line still gets major bumps.
+      // matchCurrentVersion picks the 7.x line (both lines share one depName).
+      matchDatasources: ["docker"],
+      matchDepNames: ["eclipse-ee4j/embedded-glassfish"],
+      matchCurrentVersion: "< 8.0.0",
+      allowedVersions: "< 8.0.0",
+    },
+  ],
   customManagers: [
     {
       // See renovate docs https://docs.renovatebot.com/modules/manager/regex/

--- a/scim-server-examples/scim-server-memory/src/test/java/org/apache/directory/scim/example/memory/ContainerIT.java
+++ b/scim-server-examples/scim-server-memory/src/test/java/org/apache/directory/scim/example/memory/ContainerIT.java
@@ -52,7 +52,9 @@ public class ContainerIT {
 
     Map<String, Function<ContainerConfiguration, WebAppContainer<?>>> containers = Map.of(
       "payara", config -> new PayaraContainer(config.imageName, warFile, config.timeout),
-      "glassfish", config -> new GlassfishContainer(config.imageName, warFile, config.timeout),
+      // GlassFish: one matrix entry per supported major version; image resolved from container.properties
+      "glassfish-v7", config -> new GlassfishContainer(config.imageName, warFile, config.timeout),
+      "glassfish-v8", config -> new GlassfishContainer(config.imageName, warFile, config.timeout),
       "wildfly", config -> new WildflyContainer(config.imageName, warFile, config.timeout),
       "open-liberty", config -> new OpenLibertyContainer(config.imageName, warFile, config.timeout)
     );

--- a/scim-server-examples/scim-server-memory/src/test/resources/container.properties
+++ b/scim-server-examples/scim-server-memory/src/test/resources/container.properties
@@ -17,8 +17,11 @@
 
 # renovate: versioning=semver
 payara.image=docker.io/payara/micro:7.2026.5
+# GlassFish is tracked per major version to enable parallel matrix testing.
 # renovate: versioning=semver
-glassfish.image=ghcr.io/eclipse-ee4j/embedded-glassfish:7.1.0
+glassfish-v7.image=ghcr.io/eclipse-ee4j/embedded-glassfish:7.1.0
+# renovate: versioning=semver
+glassfish-v8.image=ghcr.io/eclipse-ee4j/embedded-glassfish:8.0.2
 # renovate: versioning=semver-coerced
 wildfly.image=quay.io/wildfly/wildfly:39.0.0.Final-jdk17
 # renovate: versioning=semver-coerced


### PR DESCRIPTION
## What

Run the GlassFish integration tests against **both** supported major versions —
7.x and 8.x — in a single CI execution, instead of one image replacing the other.

- `container.properties`: split the single `glassfish.image` entry into
  `glassfish-v7.image` (`7.1.0`) and `glassfish-v8.image` (`8.0.2`), each kept on
  its own `# renovate:` line so Renovate tracks the two majors independently.
- `ContainerIT.java`: replaced the `glassfish` matrix entry with `glassfish-v7`
  and `glassfish-v8`. The per-version `*.enabled` / `*.timeout` properties fall
  out of the existing `<name>.enabled` / `<name>.timeout` convention, so
  `glassfish-v7.enabled` and `glassfish-v8.enabled` both default to `true` and a
  developer can disable either version locally.
- The other servers (Payara, WildFly, Open Liberty) are unchanged.

## Renovate

Both GlassFish lines share one `depName` (`eclipse-ee4j/embedded-glassfish`), so a
`packageRule` keeps them from drifting into each other:

- The 7.x line is constrained to the 7 series (`allowedVersions: "< 8.0.0"`,
  selected via `matchCurrentVersion: "< 8.0.0"`): it still receives minor/patch
  updates, but never jumps to 8.x.
- The 8.x line is left unconstrained, so a future GlassFish 9 release still
  surfaces a PR and a `glassfish-v9` entry can be added the same way v8 was added
  alongside v7.

Verified locally with `renovate --platform=local --dry-run` (Renovate 43) by
temporarily rolling the versions back:

| Scenario | Result |
| --- | --- |
| `glassfish-v7` = `7.0.0` | proposes `7.0.0 → 7.1.0` (minor); does **not** offer 8.x |
| `glassfish-v7` = `7.1.0` (latest 7.x) | no update |
| `glassfish-v8` = `8.0.0` | proposes `8.0.0 → 8.0.2` (patch) |

Renovate version-buckets the branches (`…-7.x` vs `…-8.x`), so the two lines stay
independent despite the shared `depName`.

Supersedes the single-version Renovate bump in #1059.
