### PR TITLE
Bump Spring Boot to 3.5.16 and 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <version.antlr4>4.13.2</version.antlr4>
     <version.resteasy>7.0.2.Final</version.resteasy>
     <!-- build against Spring Boot 3.x, test against 3 and 4 (until 3 is end of life) -->
-    <version.spring-boot3>3.5.14</version.spring-boot3>
-    <version.spring-boot4>4.0.6</version.spring-boot4>
+    <version.spring-boot3>3.5.16</version.spring-boot3>
+    <version.spring-boot4>4.1.0</version.spring-boot4>
     <version.jersey3>3.1.11</version.jersey3>
     <version.jersey4>4.0.2</version.jersey4>
     <!-- default surefire/failsafe arg lines to empty-->


### PR DESCRIPTION
Updates Spring Boot to the latest 3.x (3.5.16) and 4.x (4.1.0) releases.